### PR TITLE
Renamed pl to protolint

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,8 +4,8 @@ before:
 builds:
 - env:
   - CGO_ENABLED=0
-  main: ./cmd/pl/main.go
-  binary: pl
+  main: ./cmd/protolint/main.go
+  binary: protolint
 archive:
   replacements:
     darwin: Darwin

--- a/Makefile
+++ b/Makefile
@@ -42,14 +42,14 @@ dev/install/dep:
 ## ARG is command arguments.
 ARG=lint
 
-## run/cmd/pl runs pl with ARG
-run/cmd/pl:
-	go run cmd/pl/main.go $(ARG)
+## run/cmd/protolint runs protolint with ARG
+run/cmd/protolint:
+	go run cmd/protolint/main.go $(ARG)
 
-## run/cmd/pl/exampleconfig runs pl with ARG under _example/config
-run/cmd/pl/exampleconfig:
-	cd _example/config && go run ../../cmd/pl/main.go $(ARG)
+## run/cmd/protolint/exampleconfig runs protolint with ARG under _example/config
+run/cmd/protolint/exampleconfig:
+	cd _example/config && go run ../../cmd/protolint/main.go $(ARG)
 
-## build/cmd/pl builds pl
-build/cmd/pl:
-	go build -o pl cmd/pl/main.go
+## build/cmd/protolint builds protolint
+build/cmd/protolint:
+	go build -o protolint cmd/protolint/main.go

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ protolint is a command line tool which lints Protocol Buffer files (proto3):
 ## Installation
 
 ```
-go get -u -v github.com/yoheimuta/protolint/cmd/pl
+go get -u -v github.com/yoheimuta/protolint/cmd/protolint
 ```
 
 For non-Go users, the simplest way to install the protolint is to download a pre-built binary from this release page:
@@ -23,12 +23,12 @@ In the downloads section of each release, you can find pre-built binaries in .ta
 ## Usage
 
 ```
-pl lint example.proto example2.proto # file mode, specify multiple specific files
-pl lint .                            # directory mode, search for all .proto files recursively
-pl .                                 # same as "pl lint ."
-pl lint -config_dir_path=path/to .   # search path/to for .protolint.yaml
-pl lint -fix .                       # automatically fix some of the problems reported by some rules
-pl list                              # list all current lint rules being used
+protolint lint example.proto example2.proto # file mode, specify multiple specific files
+protolint lint .                            # directory mode, search for all .proto files recursively
+protolint .                                 # same as "protolint lint ."
+protolint lint -config_dir_path=path/to .   # search path/to for .protolint.yaml
+protolint lint -fix .                       # automatically fix some of the problems reported by some rules
+protolint list                              # list all current lint rules being used
 ```
 
 ## Rules

--- a/_example/config/.protolint.yaml
+++ b/_example/config/.protolint.yaml
@@ -16,7 +16,7 @@ lint:
       - path/to/dir
 
   # Linter rules.
-  # Run `pl list` to see all available rules.
+  # Run `protolint list` to see all available rules.
   rules:
     # Determines whether or not to include the default set of linters.
     no_default: true

--- a/cmd/protolint/main.go
+++ b/cmd/protolint/main.go
@@ -6,7 +6,6 @@ import (
 	"github.com/yoheimuta/protolint/internal/cmd"
 )
 
-// DEPRECATED: Use cmd/protolint. See https://github.com/yoheimuta/protolint/issues/20.
 func main() {
 	os.Exit(int(
 		cmd.Do(

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -14,11 +14,11 @@ const (
 Protocol Buffer Linter Command.
 
 Usage:
-  pl .
-  pl lint .
-  pl lint -fix .
-  pl lint example.proto example2.proto
-  pl list
+  protolint .
+  protolint lint .
+  protolint lint -fix .
+  protolint lint example.proto example2.proto
+  protolint list
 `
 )
 
@@ -67,14 +67,14 @@ func doLint(
 	stderr io.Writer,
 ) osutil.ExitCode {
 	if len(args) < 1 {
-		_, _ = fmt.Fprintln(stderr, "pl lint requires at least one argument. See Usage.")
+		_, _ = fmt.Fprintln(stderr, "protolint lint requires at least one argument. See Usage.")
 		_, _ = fmt.Fprint(stderr, help)
 		return osutil.ExitFailure
 	}
 
 	flags := lint.NewFlags(args)
 	if len(flags.Args()) < 1 {
-		_, _ = fmt.Fprintln(stderr, "pl lint requires at least one argument. See Usage.")
+		_, _ = fmt.Fprintln(stderr, "protolint lint requires at least one argument. See Usage.")
 		_, _ = fmt.Fprint(stderr, help)
 		return osutil.ExitFailure
 	}


### PR DESCRIPTION
ref. [pl is ambiguous with ASCII propertery list utility in osx · Issue #20 · yoheimuta/protolint](https://github.com/yoheimuta/protolint/issues/20)