### PR TITLE
Correspond line length and indent size

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ The rule set follows:
 
 - [Official Style Guide](https://developers.google.com/protocol-buffers/docs/style). This is enabled by default.
 - Formatting Style Guide. This is enabled by default.
-  - Enforce a maximum line length. The length of a line is defined as the number of Unicode characters in the line. You can configure the detail with `.protolint.yaml`.
-  - Enforce a consistent indentation style. The --fix option on the command line can automatically fix some of the problems reported by this rule. The default style is 4 spaces. You can configure the detail with `.protolint.yaml`.
+  - Enforce a maximum line length. The length of a line is defined as the number of Unicode characters in the line. The default is 80 characters. You can configure the detail with `.protolint.yaml`.
+  - Enforce a consistent indentation style. The --fix option on the command line can automatically fix some of the problems reported by this rule. The default style is 2 spaces. You can configure the detail with `.protolint.yaml`.
 
 | ID                                | Purpose                                                                  |
 |-----------------------------------|--------------------------------------------------------------------------|

--- a/_testdata/rules/indentrule/enum.proto
+++ b/_testdata/rules/indentrule/enum.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 enum enumAllowingAlias {
-    UNKNOWN = 0;
-    option allow_alias = true;
-    STARTED = 1;
-    RUNNING = 2 [(custom_option) = "hello world"];
+  UNKNOWN = 0;
+  option allow_alias = true;
+  STARTED = 1;
+  RUNNING = 2 [(custom_option) = "hello world"];
 }

--- a/_testdata/rules/indentrule/incorrect_enum.proto
+++ b/_testdata/rules/indentrule/incorrect_enum.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 enum enumAllowingAlias {
-    UNKNOWN = 0;
+  UNKNOWN = 0;
         option allow_alias = true;
-    STARTED = 1;
+  STARTED = 1;
      RUNNING = 2 [(custom_option) = "hello world"];
  }

--- a/_testdata/rules/indentrule/incorrect_message.proto
+++ b/_testdata/rules/indentrule/incorrect_message.proto
@@ -1,18 +1,18 @@
 syntax = "proto3";
 
 message outer {
-    option (my_option).a = true;
-    message inner {   // Level 2
-    int64 ival = 1;
-    }
-    repeated inner inner_message = 2;
+  option (my_option).a = true;
+  message inner {   // Level 2
+  int64 ival = 1;
+  }
+  repeated inner inner_message = 2;
 EnumAllowingAlias enum_field =3;
-    map<int32, string> my_map = 4;
+  map<int32, string> my_map = 4;
 
-    enum enumAllowingAlias {
-        option allow_alias = true;
-            UNKNOWN = 0;
-        STARTED = 1;
-        RUNNING = 2 [(custom_option) = "hello world"];
-    }
+  enum enumAllowingAlias {
+    option allow_alias = true;
+      UNKNOWN = 0;
+    STARTED = 1;
+    RUNNING = 2 [(custom_option) = "hello world"];
+  }
 }

--- a/_testdata/rules/indentrule/message.proto
+++ b/_testdata/rules/indentrule/message.proto
@@ -1,18 +1,18 @@
 syntax = "proto3";
 
 message outer {
-    option (my_option).a = true;
-    message inner {   // Level 2
-        int64 ival = 1;
-    }
-    repeated inner inner_message = 2;
-    EnumAllowingAlias enum_field =3;
-    map<int32, string> my_map = 4;
+  option (my_option).a = true;
+  message inner {   // Level 2
+    int64 ival = 1;
+  }
+  repeated inner inner_message = 2;
+  EnumAllowingAlias enum_field =3;
+  map<int32, string> my_map = 4;
 
-    enum enumAllowingAlias {
-        option allow_alias = true;
-        UNKNOWN = 0;
-        STARTED = 1;
-        RUNNING = 2 [(custom_option) = "hello world"];
-    }
+  enum enumAllowingAlias {
+    option allow_alias = true;
+    UNKNOWN = 0;
+    STARTED = 1;
+    RUNNING = 2 [(custom_option) = "hello world"];
+  }
 }

--- a/internal/addon/rules/indentRule.go
+++ b/internal/addon/rules/indentRule.go
@@ -12,8 +12,10 @@ import (
 )
 
 const (
-	// 4 spaces
-	defaultStyle   = "    "
+	// Use an indent of 2 spaces.
+	// See https://developers.google.com/protocol-buffers/docs/style#standard-file-formatting
+	defaultStyle = "  "
+
 	defaultNewline = "\n"
 )
 

--- a/internal/addon/rules/indentRule_test.go
+++ b/internal/addon/rules/indentRule_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestIndentRule_Apply(t *testing.T) {
-	space4 := strings.Repeat(" ", 4)
+	defaultSpace := strings.Repeat(" ", 2)
 
 	tests := []struct {
 		name           string
@@ -34,7 +34,7 @@ func TestIndentRule_Apply(t *testing.T) {
 		},
 		{
 			name:           "incorrect syntax",
-			inputStyle:     space4,
+			inputStyle:     defaultSpace,
 			inputProtoPath: setting_test.TestDataPath("rules", "indentrule", "incorrect_syntax.proto"),
 			wantFailures: []report.Failure{
 				report.Failuref(
@@ -45,7 +45,7 @@ func TestIndentRule_Apply(t *testing.T) {
 						Column:   5,
 					},
 					`Found an incorrect indentation style "%s". "%s" is correct.`,
-					space4,
+					"    ",
 					"",
 				),
 			},
@@ -61,7 +61,7 @@ func TestIndentRule_Apply(t *testing.T) {
 				report.Failuref(
 					meta.Position{
 						Filename: setting_test.TestDataPath("rules", "indentrule", "incorrect_enum.proto"),
-						Offset:   166,
+						Offset:   162,
 						Line:     7,
 						Column:   2,
 					},
@@ -72,24 +72,24 @@ func TestIndentRule_Apply(t *testing.T) {
 				report.Failuref(
 					meta.Position{
 						Filename: setting_test.TestDataPath("rules", "indentrule", "incorrect_enum.proto"),
-						Offset:   69,
+						Offset:   67,
 						Line:     4,
 						Column:   9,
 					},
 					`Found an incorrect indentation style "%s". "%s" is correct.`,
 					"        ",
-					space4,
+					defaultSpace,
 				),
 				report.Failuref(
 					meta.Position{
 						Filename: setting_test.TestDataPath("rules", "indentrule", "incorrect_enum.proto"),
-						Offset:   118,
+						Offset:   114,
 						Line:     6,
 						Column:   6,
 					},
 					`Found an incorrect indentation style "%s". "%s" is correct.`,
 					"     ",
-					space4,
+					defaultSpace,
 				),
 			},
 		},
@@ -104,35 +104,35 @@ func TestIndentRule_Apply(t *testing.T) {
 				report.Failuref(
 					meta.Position{
 						Filename: setting_test.TestDataPath("rules", "indentrule", "incorrect_message.proto"),
-						Offset:   106,
+						Offset:   100,
 						Line:     6,
-						Column:   5,
+						Column:   3,
 					},
 					`Found an incorrect indentation style "%s". "%s" is correct.`,
-					space4,
-					strings.Repeat(space4, 2),
+					"  ",
+					strings.Repeat(defaultSpace, 2),
 				),
 				report.Failuref(
 					meta.Position{
 						Filename: setting_test.TestDataPath("rules", "indentrule", "incorrect_message.proto"),
-						Offset:   166,
+						Offset:   156,
 						Line:     9,
 						Column:   1,
 					},
 					`Found an incorrect indentation style "%s". "%s" is correct.`,
 					"",
-					space4,
+					defaultSpace,
 				),
 				report.Failuref(
 					meta.Position{
 						Filename: setting_test.TestDataPath("rules", "indentrule", "incorrect_message.proto"),
-						Offset:   311,
+						Offset:   287,
 						Line:     14,
-						Column:   13,
+						Column:   7,
 					},
 					`Found an incorrect indentation style "%s". "%s" is correct.`,
-					strings.Repeat(space4, 3),
-					strings.Repeat(space4, 2),
+					"      ",
+					strings.Repeat(defaultSpace, 2),
 				),
 			},
 		},
@@ -202,7 +202,7 @@ func (d testData) restore() error {
 }
 
 func TestIndentRule_Apply_fix(t *testing.T) {
-	space4 := strings.Repeat(" ", 4)
+	space2 := strings.Repeat(" ", 2)
 
 	correctSyntaxPath, err := newTestData("syntax.proto")
 	if err != nil {
@@ -281,7 +281,7 @@ func TestIndentRule_Apply_fix(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			rule := rules.NewIndentRule(
-				space4,
+				space2,
 				"\n",
 				true,
 			)

--- a/internal/addon/rules/maxLineLengthRule.go
+++ b/internal/addon/rules/maxLineLengthRule.go
@@ -13,7 +13,10 @@ import (
 )
 
 const (
-	defaultMaxChars = 120
+	// Keep the line length to 80 characters.
+	// See https://developers.google.com/protocol-buffers/docs/style#standard-file-formatting
+	defaultMaxChars = 80
+
 	defaultTabChars = 4
 )
 

--- a/internal/addon/rules/maxLineLengthRule_test.go
+++ b/internal/addon/rules/maxLineLengthRule_test.go
@@ -43,7 +43,6 @@ func TestMaxLineLengthRule_Apply(t *testing.T) {
 		},
 		{
 			name:          "found long lines",
-			inputMaxChars: 80,
 			inputTabChars: 4,
 			inputProto: &parser.Proto{
 				Meta: &parser.ProtoMeta{


### PR DESCRIPTION
Changed the default values so that corresponding with the updated Style Guide.

- https://developers.google.com/protocol-buffers/docs/style#standard-file-formatting