### PR TITLE
chore: Bump parser to v3.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/yoheimuta/protolint
 
 require (
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/yoheimuta/go-protoparser v3.0.1+incompatible
+	github.com/yoheimuta/go-protoparser v3.1.0+incompatible
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/yoheimuta/go-protoparser v3.0.0+incompatible h1:NkQQydFeCTP9fFStpV6G9CGSG1ZvFpE57oRa6LS9sEA=
-github.com/yoheimuta/go-protoparser v3.0.0+incompatible/go.mod h1:NMMDARGayMyLM9oD1JUgKyF1Tv7aj9S+KcTG4lqvemo=
-github.com/yoheimuta/go-protoparser v3.0.1+incompatible h1:5T1YcOYB21IMqlE3ALcywKMeHoI5l0BYK7TFVYiaCyo=
-github.com/yoheimuta/go-protoparser v3.0.1+incompatible/go.mod h1:NMMDARGayMyLM9oD1JUgKyF1Tv7aj9S+KcTG4lqvemo=
+github.com/yoheimuta/go-protoparser v3.1.0+incompatible h1:jNZBT6Cvwm3JSkUmLHPN6pn2r7EC7WOhe0OV+S3vkkI=
+github.com/yoheimuta/go-protoparser v3.1.0+incompatible/go.mod h1:NMMDARGayMyLM9oD1JUgKyF1Tv7aj9S+KcTG4lqvemo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
ref. [Block followed by semicolon causing runtime error · Issue #66 · yoheimuta/protolint](https://github.com/yoheimuta/protolint/issues/66)