### PR TITLE
fix: Handle the case that the last rpc method of a service is having a statement block

### DIFF
--- a/_testdata/rules/indentrule/issue_74.proto
+++ b/_testdata/rules/indentrule/issue_74.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+service SearchService {
+  rpc Search (SearchRequest) returns (SearchResponse) {}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
-	github.com/yoheimuta/go-protoparser v3.1.1+incompatible
+	github.com/yoheimuta/go-protoparser v3.1.2+incompatible
 	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 // indirect
 	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/yoheimuta/go-protoparser v3.1.1+incompatible h1:LLCBubUwlE5PWlw9bZwEmNIHrporOofJ0uF0V4Us5BY=
-github.com/yoheimuta/go-protoparser v3.1.1+incompatible/go.mod h1:NMMDARGayMyLM9oD1JUgKyF1Tv7aj9S+KcTG4lqvemo=
+github.com/yoheimuta/go-protoparser v3.1.2+incompatible h1:Bsz5hAb9ILtb3VobyX5z/CtnxHkQI3yYsLi6uugFNJI=
+github.com/yoheimuta/go-protoparser v3.1.2+incompatible/go.mod h1:NMMDARGayMyLM9oD1JUgKyF1Tv7aj9S+KcTG4lqvemo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/internal/addon/rules/indentRule_test.go
+++ b/internal/addon/rules/indentRule_test.go
@@ -147,6 +147,11 @@ func TestIndentRule_Apply(t *testing.T) {
 			name:           "handle the proto containing extend. Fix https://github.com/yoheimuta/protolint/issues/63",
 			inputProtoPath: setting_test.TestDataPath("rules", "indentrule", "issue_63.proto"),
 		},
+		{
+			name: `handle the case that the last rpc method of a service is having a statement block.
+Fix https://github.com/yoheimuta/protolint/issues/74`,
+			inputProtoPath: setting_test.TestDataPath("rules", "indentrule", "issue_74.proto"),
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
ref. [False-positive by indent rule · Issue #74 · yoheimuta/protolint](https://github.com/yoheimuta/protolint/issues/74)