### PR TITLE
feat: Update parser to allow oneof to have options

### DIFF
--- a/_example/proto/issue_88/oneof_options.proto
+++ b/_example/proto/issue_88/oneof_options.proto
@@ -1,0 +1,30 @@
+// Copyright 2016 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
+syntax = "proto3";
+package validatortest;
+
+import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+import "github.com/mwitkow/go-proto-validators/validator.proto";
+
+message ExternalMsg {
+    string Identifier = 1 [(validator.field) = {regex: "^[a-z]{2,5}$"}];
+    int64 SomeValue = 2 [(validator.field) = {int_gt: 0, int_lt: 100}];
+}
+
+message OneOfMessage3 {
+    uint32 SomeInt = 1  [(validator.field) = {int_gt: 10}];
+
+    oneof type {
+        ExternalMsg one_msg = 2;
+        uint32 one_int = 3 [(validator.field) = {int_gt: 20}];
+        uint32 two_int = 4 [(validator.field) = {int_gt: 100}];
+    }
+
+    oneof something {
+        option (validator.oneof) = {required: true};
+        uint32 three_int = 5 [(validator.field) = {int_gt: 20}];
+        uint32 four_int = 6 [(validator.field) = {int_gt: 100}];
+        string five_regex = 7 [(validator.field) = {regex: "^[a-z]{2,5}$"}];
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
-	github.com/yoheimuta/go-protoparser v3.3.0+incompatible
+	github.com/yoheimuta/go-protoparser v3.4.0+incompatible
 	golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7 // indirect
 	golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/yoheimuta/go-protoparser v3.3.0+incompatible h1:/c4H0Qy/hoUvEgZoo/EpvIhvOSxDSNN5PcV+ytVenl0=
 github.com/yoheimuta/go-protoparser v3.3.0+incompatible/go.mod h1:NMMDARGayMyLM9oD1JUgKyF1Tv7aj9S+KcTG4lqvemo=
+github.com/yoheimuta/go-protoparser v3.4.0+incompatible h1:FdE033NnKLsvJFpfcy7eH9Rzl1k9f88HDmu9anoTsyY=
+github.com/yoheimuta/go-protoparser v3.4.0+incompatible/go.mod h1:NMMDARGayMyLM9oD1JUgKyF1Tv7aj9S+KcTG4lqvemo=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=


### PR DESCRIPTION
ref. [oneof options fail to parse · Issue #88 · yoheimuta/protolint](https://github.com/yoheimuta/protolint/issues/88)