### PR TITLE
Use stdout for command output

### DIFF
--- a/internal/cmd/subcmds/lint/cmdLint.go
+++ b/internal/cmd/subcmds/lint/cmdLint.go
@@ -43,7 +43,7 @@ func NewCmdLint(
 		flags,
 	)
 
-	output := stderr
+	output := stdout
 	if 0 < len(flags.OutputFilePath) {
 		output, err = os.OpenFile(flags.OutputFilePath, os.O_WRONLY|os.O_CREATE, 0666)
 		if err != nil {


### PR DESCRIPTION
To keep to unix standards, it would be nice if the tool could output to stdout. 
This makes it easier to pipe to other commands, such as `grep` or `jq`.

Additionally, when running a linter, the expected output is a list of the lint issues it has found.
While they are technically errors (with the protos), they are not *tool* errors, but a valid and expected outcome; hence, they should go to stdout.