### PR TITLE
Change exit code behaviour to return debuggable values

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -43,7 +43,7 @@ func Do(
 	switch {
 	case len(args) == 0:
 		_, _ = fmt.Fprint(stderr, help)
-		return osutil.ExitFailure
+		return osutil.ExitInternalFailure
 	default:
 		return doSub(
 			args,
@@ -78,18 +78,18 @@ func doLint(
 	if len(args) < 1 {
 		_, _ = fmt.Fprintln(stderr, "protolint lint requires at least one argument. See Usage.")
 		_, _ = fmt.Fprint(stderr, help)
-		return osutil.ExitFailure
+		return osutil.ExitInternalFailure
 	}
 
 	flags, err := lint.NewFlags(args)
 	if err != nil {
 		_, _ = fmt.Fprint(stderr, err)
-		return osutil.ExitFailure
+		return osutil.ExitInternalFailure
 	}
 	if len(flags.Args()) < 1 {
 		_, _ = fmt.Fprintln(stderr, "protolint lint requires at least one argument. See Usage.")
 		_, _ = fmt.Fprint(stderr, help)
-		return osutil.ExitFailure
+		return osutil.ExitInternalFailure
 	}
 
 	subCmd, err := lint.NewCmdLint(
@@ -99,7 +99,7 @@ func doLint(
 	)
 	if err != nil {
 		_, _ = fmt.Fprint(stderr, err)
-		return osutil.ExitFailure
+		return osutil.ExitInternalFailure
 	}
 	return subCmd.Run()
 }

--- a/internal/cmd/protocgenprotolint/cmd.go
+++ b/internal/cmd/protocgenprotolint/cmd.go
@@ -39,7 +39,7 @@ func Do(
 	subCmd, err := newSubCmd(stdin, stdout, stderr)
 	if err != nil {
 		_, _ = fmt.Fprintln(stderr, err)
-		return osutil.ExitFailure
+		return osutil.ExitInternalFailure
 	}
 	return subCmd.Run()
 }

--- a/internal/cmd/subcmds/lint/cmdLint.go
+++ b/internal/cmd/subcmds/lint/cmdLint.go
@@ -102,6 +102,7 @@ func (c *CmdLint) run() ([]report.Failure, error) {
 	return allFailures, nil
 }
 
+// ParseError represents the error returned through a parsing exception.
 type ParseError struct {
 	Message string
 }

--- a/internal/cmd/subcmds/lint/cmdLint.go
+++ b/internal/cmd/subcmds/lint/cmdLint.go
@@ -66,13 +66,7 @@ func (c *CmdLint) Run() osutil.ExitCode {
 	failures, err := c.run()
 	if err != nil {
 		_, _ = fmt.Fprintln(c.stderr, err)
-
-		switch err.(type) {
-		case ParseError:
-			return osutil.ExitParseFailure
-		default:
-			return osutil.ExitInternalFailure
-		}
+		return osutil.ExitInternalFailure
 	}
 
 	err = c.config.reporter.Report(c.output, failures)

--- a/internal/cmd/subcmds/lint/cmdLint.go
+++ b/internal/cmd/subcmds/lint/cmdLint.go
@@ -73,13 +73,13 @@ func (c *CmdLint) Run() osutil.ExitCode {
 		}
 
 		_, _ = fmt.Fprintln(c.stderr, err)
-		return osutil.ExitFailure
+		return osutil.ExitInternalFailure
 	}
 
 	err = c.config.reporter.Report(c.output, failures)
 	if err != nil {
 		_, _ = fmt.Fprintln(c.stderr, err)
-		return osutil.ExitFailure
+		return osutil.ExitInternalFailure
 	}
 
 	if 0 < len(failures) {

--- a/internal/cmd/subcmds/lint/cmdLint.go
+++ b/internal/cmd/subcmds/lint/cmdLint.go
@@ -1,7 +1,6 @@
 package lint
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -66,14 +65,14 @@ func NewCmdLint(
 func (c *CmdLint) Run() osutil.ExitCode {
 	failures, err := c.run()
 	if err != nil {
-		pe := ParseError{}
-		if errors.As(err, &pe) {
-			_, _ = fmt.Fprintln(c.stderr, pe)
-			return osutil.ExitParseFailure
-		}
-
 		_, _ = fmt.Fprintln(c.stderr, err)
-		return osutil.ExitInternalFailure
+
+		switch err.(type) {
+		case ParseError:
+			return osutil.ExitParseFailure
+		default:
+			return osutil.ExitInternalFailure
+		}
 	}
 
 	err = c.config.reporter.Report(c.output, failures)

--- a/internal/cmd/subcmds/list/cmdList.go
+++ b/internal/cmd/subcmds/list/cmdList.go
@@ -33,7 +33,7 @@ func NewCmdList(
 func (c *CmdList) Run() osutil.ExitCode {
 	err := c.run()
 	if err != nil {
-		return osutil.ExitFailure
+		return osutil.ExitInternalFailure
 	}
 	return osutil.ExitSuccess
 }

--- a/internal/osutil/exitCode.go
+++ b/internal/osutil/exitCode.go
@@ -6,7 +6,8 @@ type ExitCode int
 // ExitCode constants.
 const (
 	ExitSuccess ExitCode = iota
-	ExitFailure
+	ExitInternalFailure
+	ExitRuntimeFailure // runtime exceptions in go throw 2 by default
 	ExitLintFailure
 	ExitParseFailure
 )

--- a/internal/osutil/exitCode.go
+++ b/internal/osutil/exitCode.go
@@ -5,9 +5,7 @@ type ExitCode int
 
 // ExitCode constants.
 const (
-	ExitSuccess ExitCode = iota
-	ExitInternalFailure
-	ExitRuntimeFailure // runtime exceptions in go throw 2 by default
-	ExitLintFailure
-	ExitParseFailure
+	ExitSuccess         ExitCode = iota
+	ExitLintFailure              // Lint errors, exclusively.
+	ExitInternalFailure          // All other errors: parsing, internal, runtime errors.
 )

--- a/internal/osutil/exitCode.go
+++ b/internal/osutil/exitCode.go
@@ -7,4 +7,6 @@ type ExitCode int
 const (
 	ExitSuccess ExitCode = iota
 	ExitFailure
+	ExitLintFailure
+	ExitParseFailure
 )


### PR DESCRIPTION
This changes the current exit code behaviour to be dependent on the error type returned.
exitcode 1: internal error
exitcode 2: runtime error
exitcode 3: linting error
exitcode 4: parsing error

This is an iniial implementation of the error handling changes suggested in \#101.
However, having recognised that not all error codes are necessarily linting or parsing, but can also be runtime (eg mem violation) or internal (eg usage: missing args, unknown flags, etc), I have expanded the error codes available.