### PR TITLE
fix: Include dependencies that are automatically injected.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,13 +9,16 @@ require (
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/yoheimuta/go-protoparser v1.3.1-0.20191124070251-d3645978b4cf
+	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20191112182307-2180aed22343 // indirect
 	golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056 // indirect
 	golang.org/x/text v0.3.2 // indirect
+	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/genproto v0.0.0-20191114150713-6bbd007550de // indirect
 	google.golang.org/grpc v1.25.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.5
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )
 
 go 1.13


### PR DESCRIPTION
ref. 

- https://github.com/yoheimuta/protolint/pull/118
- https://app.circleci.com/jobs/github/yoheimuta/protolint/502

[memo] I guess this misleading behavior should be fixed somehow (or PR CI should fail fast).