### PR TITLE
chore: Update go version to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   lint:
     docker:
-      - image: circleci/golang:1.12.5
+      - image: circleci/golang:1.13.4
         environment:
           GO111MODULE: "on"
     working_directory: /go/src/github.com/yoheimuta/protolint
@@ -12,7 +12,7 @@ jobs:
       - run: make test/lint
   test:
     docker:
-      - image: circleci/golang:1.12.5
+      - image: circleci/golang:1.13.4
         environment:
           GO111MODULE: "on"
     working_directory: /go/src/github.com/yoheimuta/protolint
@@ -21,7 +21,7 @@ jobs:
       - run: make test
   deploy:
     docker:
-      - image: circleci/golang:1.12.5
+      - image: circleci/golang:1.13.4
         environment:
           GO111MODULE: "on"
     working_directory: /go/src/github.com/yoheimuta/protolint

--- a/Dockerfile.protolint
+++ b/Dockerfile.protolint
@@ -1,4 +1,4 @@
-FROM golang:1.12.9-alpine3.10 AS builder
+FROM golang:1.13.4-alpine3.10 AS builder
 RUN apk update
 RUN apk add --virtual build-dependencies build-base git
 ADD . ./protolint

--- a/go.mod
+++ b/go.mod
@@ -9,16 +9,13 @@ require (
 	github.com/mitchellh/go-testing-interface v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/yoheimuta/go-protoparser v1.3.1-0.20191124070251-d3645978b4cf
-	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20191112182307-2180aed22343 // indirect
 	golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056 // indirect
 	golang.org/x/text v0.3.2 // indirect
-	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/genproto v0.0.0-20191114150713-6bbd007550de // indirect
 	google.golang.org/grpc v1.25.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.5
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )
 
 go 1.13


### PR DESCRIPTION
ref. [fix: Include dependencies that are automatically injected. by yoheimuta · Pull Request #119 · yoheimuta/protolint](https://github.com/yoheimuta/protolint/pull/119)

For fixing the annoying go.mod diff below.

```
  ⨯ release failed after 13.22s error=git is currently in a dirty state, please check in your pipeline what can be changing the following files:
 M go.mod
```

- ref. https://circleci.com/gh/yoheimuta/protolint/502