### PR TITLE
Fix empty fields within option/123

### DIFF
--- a/_testdata/parser/issue_123.proto
+++ b/_testdata/parser/issue_123.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+service Foo {
+    rpc Bar(Baz) returns (Baz) {
+        option (opt) = {
+            empty : {}
+        };
+    }
+}
+
+message Baz {}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/hashicorp/go-hclog v0.10.0
 	github.com/hashicorp/go-plugin v1.0.1
-	github.com/yoheimuta/go-protoparser/v4 v4.1.0
+	github.com/yoheimuta/go-protoparser/v4 v4.1.1
 	google.golang.org/grpc v1.25.1
 	gopkg.in/yaml.v2 v2.2.5
 )

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/yoheimuta/go-protoparser/v4 v4.1.0 h1:qdJ0kDEzHCZpuvU5jaHT6/+GfGxh6EtzZMyyZULWD7M=
-github.com/yoheimuta/go-protoparser/v4 v4.1.0/go.mod h1:AHNNnSWnb0UoL4QgHPiOAg2BniQceFscPI5X/BZNHl8=
+github.com/yoheimuta/go-protoparser/v4 v4.1.1 h1:fOyipBF2mZmDEEpehH1pP9bnwVjAmvUjmqHsDXiqJKI=
+github.com/yoheimuta/go-protoparser/v4 v4.1.1/go.mod h1:AHNNnSWnb0UoL4QgHPiOAg2BniQceFscPI5X/BZNHl8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=


### PR DESCRIPTION
```
❯❯❯ make build/cmd/protolint
go build \
                -ldflags "-X github.com/yoheimuta/protolint/internal/cmd.version=`git describe --tags --abbrev=0` -X github.com/yoheimuta/protolint/internal/cmd.revision=`git rev-parse --short HEAD`" \
                -o protolint \
                cmd/protolint/main.go
❯❯❯ ./protolint _testdata/parser
found "\"}\"(Token=15, Pos=_testdata/parser/issue_123.proto:6:22)" but expected [ident] at /Users/yoshimutayohei/.go/pkg/mod/github.com/yoheimuta/go-protoparser/v4@v4.1.0/parser/option.go:93. Use -v for more details


❯❯❯ make build/cmd/protolint
go build \
                -ldflags "-X github.com/yoheimuta/protolint/internal/cmd.version=`git describe --tags --abbrev=0` -X github.com/yoheimuta/protolint/internal/cmd.revision=`git rev-parse --short HEAD`" \
                -o protolint \
                cmd/protolint/main.go
go: downloading github.com/yoheimuta/go-protoparser/v4 v4.1.1
go: extracting github.com/yoheimuta/go-protoparser/v4 v4.1.1
go: finding github.com/yoheimuta/go-protoparser/v4 v4.1.1
/y/W/p/g/s/g/y/protolint ❯❯❯ ./protolint _testdata/parser
[_testdata/parser/issue_123.proto:4:5] Found an incorrect indentation style "    ". "  " is correct.
[_testdata/parser/issue_123.proto:8:5] Found an incorrect indentation style "    ". "  " is correct.
[_testdata/parser/issue_123.proto:5:9] Found an incorrect indentation style "        ". "    " is correct.
```