### PR TITLE
add -no-error-on-unmatched-pattern option to lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ protolint lint -config_path=path/to/your_protolint.yaml . # use path/to/your_pro
 protolint lint -config_dir_path=path/to .   # search path/to for .protolint.yaml
 protolint lint -fix .                       # automatically fix some of the problems reported by some rules
 protolint lint -v .                         # with verbose output to investigate the parsing error
+protolint lint -no-error-on-unmatched-pattern . # exits with success code even if no file is found (file & directory mode)
 protolint lint -reporter junit .            # output results in JUnit XML format
 protolint lint -output_file=path/to/out.txt # output results to path/to/out.txt
 protolint lint -plugin ./my_custom_rule1 -plugin ./my_custom_rule2 .   # run custom lint rules.

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/yoheimuta/protolint/internal/cmd/subcmds/lint"
 	"github.com/yoheimuta/protolint/internal/cmd/subcmds/list"
@@ -99,6 +100,11 @@ func doLint(
 	)
 	if err != nil {
 		_, _ = fmt.Fprint(stderr, err)
+		if flags.NoErrorOnUnmatchedPattern &&
+			(strings.Contains(err.Error(), "not found protocol buffer files") ||
+				strings.Contains(err.Error(), "system cannot find the file")) {
+			return osutil.ExitSuccess
+		}
 		return osutil.ExitInternalFailure
 	}
 	return subCmd.Run()

--- a/internal/cmd/subcmds/lint/flags.go
+++ b/internal/cmd/subcmds/lint/flags.go
@@ -16,14 +16,15 @@ import (
 type Flags struct {
 	*flag.FlagSet
 
-	FilePaths      []string
-	ConfigPath     string
-	ConfigDirPath  string
-	FixMode        bool
-	Reporter       report.Reporter
-	OutputFilePath string
-	Verbose        bool
-	Plugins        []shared.RuleSet
+	FilePaths                 []string
+	ConfigPath                string
+	ConfigDirPath             string
+	FixMode                   bool
+	Reporter                  report.Reporter
+	OutputFilePath            string
+	Verbose                   bool
+	NoErrorOnUnmatchedPattern bool
+	Plugins                   []shared.RuleSet
 }
 
 // NewFlags creates a new Flags.
@@ -76,6 +77,12 @@ func NewFlags(
 		"v",
 		false,
 		"verbose output that includes parsing process details",
+	)
+	f.BoolVar(
+		&f.NoErrorOnUnmatchedPattern,
+		"no-error-on-unmatched-pattern",
+		false,
+		"exits with 0 when no file is matched",
 	)
 
 	_ = f.Parse(args)


### PR DESCRIPTION
fixes #133 