### PR TITLE
fix: Calculate the correct relative target path even when the cwd is symlink

### DIFF
--- a/internal/linter/file/protoSet.go
+++ b/internal/linter/file/protoSet.go
@@ -44,6 +44,10 @@ func collectAllProtoFilesFromArgs(
 	if err != nil {
 		return nil, err
 	}
+	// Eval a possible symlink for the cwd to calculate the correct relative paths in the next step.
+	if newPath, err := filepath.EvalSymlinks(absCwd); err == nil {
+		absCwd = newPath
+	}
 
 	var fs []ProtoFile
 	for _, path := range targetPaths {


### PR DESCRIPTION
ref. [Unexpected error when you run a protolint from the working directory which is symlink · Issue #136 · yoheimuta/protolint](https://github.com/yoheimuta/protolint/issues/136)