### PR TITLE
fix: Remove an unnecessary dependency to sh

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -84,7 +84,7 @@ func doLint(
 
 	flags, err := lint.NewFlags(args)
 	if err != nil {
-		_, _ = fmt.Fprint(stderr, err)
+		_, _ = fmt.Fprintln(stderr, err)
 		return osutil.ExitInternalFailure
 	}
 	if len(flags.Args()) < 1 {

--- a/internal/cmd/subcmds/pluginFlag.go
+++ b/internal/cmd/subcmds/pluginFlag.go
@@ -40,7 +40,7 @@ func (f *PluginFlag) BuildPlugins(verbose bool) ([]shared.RuleSet, error) {
 		client := plugin.NewClient(&plugin.ClientConfig{
 			HandshakeConfig: shared.Handshake,
 			Plugins:         shared.PluginMap,
-			Cmd:             exec.Command("sh", "-c", value),
+			Cmd:             exec.Command(value),
 			AllowedProtocols: []plugin.Protocol{
 				plugin.ProtocolGRPC,
 			},


### PR DESCRIPTION
ref. [Protolint doesn't work with -plugin in windows · Issue #144 · yoheimuta/protolint](https://github.com/yoheimuta/protolint/issues/144)