### PR TITLE
Support the cross-platform file path format in a config file

### DIFF
--- a/_example/config/.protolint.yaml
+++ b/_example/config/.protolint.yaml
@@ -4,7 +4,8 @@ lint:
   ignores:
     - id: MESSAGE_NAMES_UPPER_CAMEL_CASE
       files:
-        - ../proto/simple.proto
+        # NOTE: UNIX paths will be properly accepted by both UNIX and Windows.
+        - _example/proto/simple.proto
     - id: ENUM_NAMES_UPPER_CAMEL_CASE
       files:
         - path/to/foo.proto
@@ -13,12 +14,14 @@ lint:
   files:
     # The specific files to exclude.
     exclude:
+      # NOTE: UNIX paths will be properly accepted by both UNIX and Windows.
       - path/to/file
 
   # Linter directories to walk.
   directories:
     # The specific directories to exclude.
     exclude:
+      # NOTE: UNIX paths will be properly accepted by both UNIX and Windows.
       - path/to/dir
 
   # Linter rules.

--- a/internal/filepathutil/platform.go
+++ b/internal/filepathutil/platform.go
@@ -5,22 +5,44 @@ import (
 	"strings"
 )
 
+const unixPathSeparator = '/'
+
 // OSPathSeparator is just a variable that is equal to os.PathSeparator.
 // It's set by outside for mainly test usage.
 var OSPathSeparator = os.PathSeparator
 
 // IsSameUnixPath compares an unix path to a cross platform path.
 //
-// The interpretation of the former depends on the platform it runs.
+// The interpretation of the unix path depends on the platform it runs.
 func IsSameUnixPath(unixPath, crossPlatformPath string) bool {
-	unixPathSeparator := '/'
 	if OSPathSeparator == unixPathSeparator {
 		return unixPath == crossPlatformPath
 	}
+	return convertToOSPath(unixPath) == crossPlatformPath
+}
+
+// HasUnixPathPrefix checks whether a cross platform path has an unix path as its prefix.
+//
+// The interpretation of the unix path depends on the platform it runs.
+func HasUnixPathPrefix(crossPlatformPath, unixPath string) bool {
+	if OSPathSeparator == unixPathSeparator {
+		return strings.HasPrefix(crossPlatformPath, unixPath)
+	}
+	return strings.HasPrefix(
+		crossPlatformPath,
+		convertToOSPath(unixPath),
+	)
+}
+
+func convertToOSPath(unixPath string) string {
 	return strings.Replace(
 		unixPath,
 		string(unixPathSeparator),
-		string(OSPathSeparator),
+		osPathSeparator(),
 		-1,
-	) == crossPlatformPath
+	)
+}
+
+func osPathSeparator() string {
+	return string(OSPathSeparator)
 }

--- a/internal/filepathutil/platform.go
+++ b/internal/filepathutil/platform.go
@@ -1,0 +1,26 @@
+package filepathutil
+
+import (
+	"os"
+	"strings"
+)
+
+// OSPathSeparator is just a variable that is equal to os.PathSeparator.
+// It's set by outside for mainly test usage.
+var OSPathSeparator = os.PathSeparator
+
+// IsSameUnixPath compares an unix path to a cross platform path.
+//
+// The interpretation of the former depends on the platform it runs.
+func IsSameUnixPath(unixPath, crossPlatformPath string) bool {
+	unixPathSeparator := '/'
+	if OSPathSeparator == unixPathSeparator {
+		return unixPath == crossPlatformPath
+	}
+	return strings.Replace(
+		unixPath,
+		string(unixPathSeparator),
+		string(OSPathSeparator),
+		-1,
+	) == crossPlatformPath
+}

--- a/internal/linter/config/directories.go
+++ b/internal/linter/config/directories.go
@@ -1,8 +1,7 @@
 package config
 
 import (
-	"os"
-	"strings"
+	"github.com/yoheimuta/protolint/internal/filepathutil"
 )
 
 // Directories represents the target directories.
@@ -14,7 +13,8 @@ func (d Directories) shouldSkipRule(
 	displayPath string,
 ) bool {
 	for _, exclude := range d.Exclude {
-		if strings.HasPrefix(displayPath, exclude+string(os.PathSeparator)) {
+		if filepathutil.HasUnixPathPrefix(displayPath,
+			exclude+string(filepathutil.OSPathSeparator)) {
 			return true
 		}
 	}

--- a/internal/linter/config/externalConfig_test.go
+++ b/internal/linter/config/externalConfig_test.go
@@ -32,6 +32,7 @@ func TestExternalConfig_ShouldSkipRule(t *testing.T) {
 				Exclude: []string{
 					"path/to/dir",
 					"/path/to/dir2",
+					`\path\to\dir_windows`,
 				},
 			},
 			Files: config.Files{
@@ -230,10 +231,32 @@ func TestExternalConfig_ShouldSkipRule(t *testing.T) {
 			wantSkipRule:     true,
 		},
 		{
+			name:                        "exclude the matched windows directory",
+			externalConfig:              noDefaultExternalConfig,
+			inputRuleID:                 "FIELD_NAMES_LOWER_SNAKE_CASE",
+			inputDisplayPath:            `\path\to\dir_windows\foo.proto`,
+			inputIsWindowsPathSeparator: true,
+			wantSkipRule:                true,
+		},
+		{
+			name:                        "exclude the matched windows directory by referring to an unix filepath",
+			externalConfig:              noDefaultExternalConfig,
+			inputRuleID:                 "FIELD_NAMES_LOWER_SNAKE_CASE",
+			inputDisplayPath:            `\path\to\dir2\child\bar.proto`,
+			inputIsWindowsPathSeparator: true,
+			wantSkipRule:                true,
+		},
+		{
 			name:             "not exclude the another directory",
 			externalConfig:   noDefaultExternalConfig,
 			inputRuleID:      "FIELD_NAMES_LOWER_SNAKE_CASE",
 			inputDisplayPath: "path/to/dir3/bar.proto",
+		},
+		{
+			name:             "not exclude the unix directory by referring to a windows directory",
+			externalConfig:   noDefaultExternalConfig,
+			inputRuleID:      "FIELD_NAMES_LOWER_SNAKE_CASE",
+			inputDisplayPath: `/path/to/dir_windows/bar.proto`,
 		},
 		{
 			name:             "exclude the matched file",

--- a/internal/linter/config/externalConfig_test.go
+++ b/internal/linter/config/externalConfig_test.go
@@ -15,7 +15,7 @@ func TestExternalConfig_ShouldSkipRule(t *testing.T) {
 					ID: "ENUM_FIELD_NAMES_UPPER_SNAKE_CASE",
 					Files: []string{
 						"path/to/foo.proto",
-						"path/to/bar.proto",
+						"/path/to/bar.proto",
 					},
 				},
 				{
@@ -28,7 +28,13 @@ func TestExternalConfig_ShouldSkipRule(t *testing.T) {
 			Directories: config.Directories{
 				Exclude: []string{
 					"path/to/dir",
-					"path/to/dir2",
+					"/path/to/dir2",
+				},
+			},
+			Files: config.Files{
+				Exclude: []string{
+					"path/to/file.proto",
+					"/path/to/file2.proto",
 				},
 			},
 			Rules: struct {
@@ -41,6 +47,8 @@ func TestExternalConfig_ShouldSkipRule(t *testing.T) {
 				Add: []string{
 					"FIELD_NAMES_LOWER_SNAKE_CASE",
 					"MESSAGE_NAMES_UPPER_CAMEL_CASE",
+					"ENUM_FIELD_NAMES_UPPER_SNAKE_CASE",
+					"ENUM_NAMES_UPPER_CAMEL_CASE",
 				},
 				Remove: []string{
 					"RPC_NAMES_UPPER_CAMEL_CASE",
@@ -106,6 +114,13 @@ func TestExternalConfig_ShouldSkipRule(t *testing.T) {
 			wantSkipRule:     true,
 		},
 		{
+			name:             "ignore ENUM_FIELD_NAMES_UPPER_SNAKE_CASE",
+			externalConfig:   noDefaultExternalConfig,
+			inputRuleID:      "ENUM_FIELD_NAMES_UPPER_SNAKE_CASE",
+			inputDisplayPath: "/path/to/bar.proto",
+			wantSkipRule:     true,
+		},
+		{
 			name:             "ignore ENUM_NAMES_UPPER_CAMEL_CASE",
 			externalConfig:   noDefaultExternalConfig,
 			inputRuleID:      "ENUM_NAMES_UPPER_CAMEL_CASE",
@@ -116,6 +131,18 @@ func TestExternalConfig_ShouldSkipRule(t *testing.T) {
 			name:             "not ignore FIELD_NAMES_LOWER_SNAKE_CASE",
 			externalConfig:   noDefaultExternalConfig,
 			inputRuleID:      "FIELD_NAMES_LOWER_SNAKE_CASE",
+			inputDisplayPath: "/path/to/bar.proto",
+		},
+		{
+			name:             "not ignore ENUM_FIELD_NAMES_UPPER_SNAKE_CASE because of a file mismatch",
+			externalConfig:   noDefaultExternalConfig,
+			inputRuleID:      "ENUM_FIELD_NAMES_UPPER_SNAKE_CASE",
+			inputDisplayPath: "path/to/baz.proto",
+		},
+		{
+			name:             "not ignore ENUM_NAMES_UPPER_CAMEL_CASE because of a file mismatch",
+			externalConfig:   noDefaultExternalConfig,
+			inputRuleID:      "ENUM_NAMES_UPPER_CAMEL_CASE",
 			inputDisplayPath: "path/to/bar.proto",
 		},
 		{
@@ -165,14 +192,14 @@ func TestExternalConfig_ShouldSkipRule(t *testing.T) {
 			name:             "exclude the another directory",
 			externalConfig:   noDefaultExternalConfig,
 			inputRuleID:      "FIELD_NAMES_LOWER_SNAKE_CASE",
-			inputDisplayPath: "path/to/dir2/bar.proto",
+			inputDisplayPath: "/path/to/dir2/bar.proto",
 			wantSkipRule:     true,
 		},
 		{
 			name:             "exclude the child directory",
 			externalConfig:   noDefaultExternalConfig,
 			inputRuleID:      "FIELD_NAMES_LOWER_SNAKE_CASE",
-			inputDisplayPath: "path/to/dir2/child/bar.proto",
+			inputDisplayPath: "/path/to/dir2/child/bar.proto",
 			wantSkipRule:     true,
 		},
 		{
@@ -180,6 +207,32 @@ func TestExternalConfig_ShouldSkipRule(t *testing.T) {
 			externalConfig:   noDefaultExternalConfig,
 			inputRuleID:      "FIELD_NAMES_LOWER_SNAKE_CASE",
 			inputDisplayPath: "path/to/dir3/bar.proto",
+		},
+		{
+			name:             "exclude the matched file",
+			externalConfig:   noDefaultExternalConfig,
+			inputRuleID:      "FIELD_NAMES_LOWER_SNAKE_CASE",
+			inputDisplayPath: "path/to/file.proto",
+			wantSkipRule:     true,
+		},
+		{
+			name:             "exclude the matched file",
+			externalConfig:   noDefaultExternalConfig,
+			inputRuleID:      "FIELD_NAMES_LOWER_SNAKE_CASE",
+			inputDisplayPath: "/path/to/file2.proto",
+			wantSkipRule:     true,
+		},
+		{
+			name:             "not exclude the unmatched file",
+			externalConfig:   noDefaultExternalConfig,
+			inputRuleID:      "FIELD_NAMES_LOWER_SNAKE_CASE",
+			inputDisplayPath: "/path/to/file3.proto",
+		},
+		{
+			name:             "not exclude the unmatched file path",
+			externalConfig:   noDefaultExternalConfig,
+			inputRuleID:      "FIELD_NAMES_LOWER_SNAKE_CASE",
+			inputDisplayPath: "path/to1/file.proto",
 		},
 	} {
 		test := test

--- a/internal/linter/config/externalConfig_test.go
+++ b/internal/linter/config/externalConfig_test.go
@@ -38,6 +38,7 @@ func TestExternalConfig_ShouldSkipRule(t *testing.T) {
 				Exclude: []string{
 					"path/to/file.proto",
 					"/path/to/file2.proto",
+					`path\to\file_windows.proto`,
 				},
 			},
 			Rules: struct {
@@ -249,6 +250,22 @@ func TestExternalConfig_ShouldSkipRule(t *testing.T) {
 			wantSkipRule:     true,
 		},
 		{
+			name:                        "exclude the matched windows file",
+			externalConfig:              noDefaultExternalConfig,
+			inputRuleID:                 "FIELD_NAMES_LOWER_SNAKE_CASE",
+			inputDisplayPath:            `path\to\file_windows.proto`,
+			inputIsWindowsPathSeparator: true,
+			wantSkipRule:                true,
+		},
+		{
+			name:                        "exclude the matched windows file by referring to an unix file",
+			externalConfig:              noDefaultExternalConfig,
+			inputRuleID:                 "FIELD_NAMES_LOWER_SNAKE_CASE",
+			inputDisplayPath:            `\path\to\file2.proto`,
+			inputIsWindowsPathSeparator: true,
+			wantSkipRule:                true,
+		},
+		{
 			name:             "not exclude the unmatched file",
 			externalConfig:   noDefaultExternalConfig,
 			inputRuleID:      "FIELD_NAMES_LOWER_SNAKE_CASE",
@@ -259,6 +276,12 @@ func TestExternalConfig_ShouldSkipRule(t *testing.T) {
 			externalConfig:   noDefaultExternalConfig,
 			inputRuleID:      "FIELD_NAMES_LOWER_SNAKE_CASE",
 			inputDisplayPath: "path/to1/file.proto",
+		},
+		{
+			name:             "not exclude the unix file by referring to a windows path",
+			externalConfig:   noDefaultExternalConfig,
+			inputRuleID:      "FIELD_NAMES_LOWER_SNAKE_CASE",
+			inputDisplayPath: `path/to/file_windows.proto`,
 		},
 	} {
 		test := test

--- a/internal/linter/config/files.go
+++ b/internal/linter/config/files.go
@@ -1,5 +1,7 @@
 package config
 
+import "github.com/yoheimuta/protolint/internal/stringsutil"
+
 // Files represents the target files.
 type Files struct {
 	Exclude []string `yaml:"exclude"`
@@ -8,10 +10,5 @@ type Files struct {
 func (d Files) shouldSkipRule(
 	displayPath string,
 ) bool {
-	for _, exclude := range d.Exclude {
-		if displayPath == exclude {
-			return true
-		}
-	}
-	return false
+	return stringsutil.ContainsCrossPlatformPathInSlice(displayPath, d.Exclude)
 }

--- a/internal/linter/config/ignore.go
+++ b/internal/linter/config/ignore.go
@@ -15,5 +15,5 @@ func (i Ignore) shouldSkipRule(
 	if i.ID != ruleID {
 		return false
 	}
-	return stringsutil.ContainsStringInSlice(displayPath, i.Files)
+	return stringsutil.ContainsCrossPlatformPathInSlice(displayPath, i.Files)
 }

--- a/internal/stringsutil/slice.go
+++ b/internal/stringsutil/slice.go
@@ -1,5 +1,7 @@
 package stringsutil
 
+import "github.com/yoheimuta/protolint/internal/filepathutil"
+
 // ContainsStringInSlice searches the haystack for the needle.
 func ContainsStringInSlice(
 	needle string,
@@ -7,6 +9,19 @@ func ContainsStringInSlice(
 ) bool {
 	for _, h := range haystack {
 		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsCrossPlatformPathInSlice searches the unix path haystack for the cross-platform needle.
+func ContainsCrossPlatformPathInSlice(
+	needle string,
+	unixPathHaystack []string,
+) bool {
+	for _, h := range unixPathHaystack {
+		if filepathutil.IsSameUnixPath(h, needle) {
 			return true
 		}
 	}


### PR DESCRIPTION
ref. [protolint.yaml: File paths are not uniformly handled in UNIX and Windows · Issue #143 · yoheimuta/protolint](https://github.com/yoheimuta/protolint/issues/143)