### PR TITLE
Allow pre-commit to install protolint with go

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,12 @@
 ---
 - id: protolint
   name: Lint Protocol Buffer Files
+  description: Runs protolint to lint Protocol Buffer files
+  language: go
+  types: ["proto"]
+  entry: protolint lint
+- id: protolint-docker
+  name: Lint Protocol Buffer Files
   description: Runs protolint Docker image to lint Protocol Buffer files
   language: docker_image
   types: ["proto"]

--- a/README.md
+++ b/README.md
@@ -86,13 +86,21 @@ protolint does not require configuration by default, for the majority of project
 
 ## Version Control Integration
 
-protolint is available as a [pre-commit](https://pre-commit.com) hook.  Add this to your `.pre-commit-config.yaml` in your repository:
+protolint is available as a [pre-commit](https://pre-commit.com) hook.  Add this to your `.pre-commit-config.yaml` in your repository to run protolint with Go:
 ```yaml
 repos:
   - repo: https://github.com/yoheimuta/protolint
     rev: master
     hooks:
       - id: protolint
+```
+or alternatively use this to run protolint with Docker:
+```yaml
+repos:
+  - repo: https://github.com/yoheimuta/protolint
+    rev: master
+    hooks:
+      - id: protolint-docker
 ```
 
 ## Editor Integration


### PR DESCRIPTION
Add a new pre-commit hook to install protolint with go.
Change the existing pre-commit hook id to include docker.

This will allow pre-commit to use either Go or Docker to run protolint, depending on which hook id is selected in the `.pre-commit-config.yaml` config.

Updated after comment from pre-commit maintainer at https://github.com/pre-commit/pre-commit.com/pull/455