### PR TITLE
Fix pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,7 +2,7 @@
 - id: protolint
   name: Lint Protocol Buffer Files
   description: Runs protolint to lint Protocol Buffer files
-  language: go
+  language: golang
   types: ["proto"]
   entry: protolint lint
 - id: protolint-docker


### PR DESCRIPTION
Language should be `golang` instead of `go`. Sorry for the confusion.

https://pre-commit.com/#golang