### PR TITLE
Fixed: Linter fails on negative enum values

### DIFF
--- a/_example/proto/issue_140/negative_enum_field.proto
+++ b/_example/proto/issue_140/negative_enum_field.proto
@@ -1,0 +1,7 @@
+syntax = "proto2";
+
+enum TestNegativeValue {
+    NEGATIVE_CONSTANT = -1;
+    ZERO_CONSTANT = 0;
+    POSITIVE_CONSTANT = 1;
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/golang/protobuf v1.3.2
 	github.com/hashicorp/go-hclog v0.10.0
 	github.com/hashicorp/go-plugin v1.0.1
-	github.com/yoheimuta/go-protoparser/v4 v4.2.0
+	github.com/yoheimuta/go-protoparser/v4 v4.3.0
 	google.golang.org/grpc v1.25.1
 	gopkg.in/yaml.v2 v2.2.5
 )

--- a/go.sum
+++ b/go.sum
@@ -41,8 +41,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/yoheimuta/go-protoparser/v4 v4.2.0 h1:fv8kXyAPg79nbofyn605+ChewmT4sr+pOfHeVQKOWbg=
-github.com/yoheimuta/go-protoparser/v4 v4.2.0/go.mod h1:AHNNnSWnb0UoL4QgHPiOAg2BniQceFscPI5X/BZNHl8=
+github.com/yoheimuta/go-protoparser/v4 v4.3.0 h1:Onjbe74w3OIwdI1IHX9oTmnn8LnCDp4gCnDH/ee6ryA=
+github.com/yoheimuta/go-protoparser/v4 v4.3.0/go.mod h1:AHNNnSWnb0UoL4QgHPiOAg2BniQceFscPI5X/BZNHl8=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=


### PR DESCRIPTION
ref. [Linter fails on negative enum values · Issue #140 · yoheimuta/protolint](https://github.com/yoheimuta/protolint/issues/140)