### PR TITLE
Handle config file path more explicitly

### DIFF
--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -99,7 +99,7 @@ func doLint(
 		stderr,
 	)
 	if err != nil {
-		_, _ = fmt.Fprint(stderr, err)
+		_, _ = fmt.Fprintln(stderr, err)
 		if flags.NoErrorOnUnmatchedPattern &&
 			(strings.Contains(err.Error(), "not found protocol buffer files") ||
 				strings.Contains(err.Error(), "system cannot find the file")) {

--- a/internal/cmd/subcmds/lint/cmdLint.go
+++ b/internal/cmd/subcmds/lint/cmdLint.go
@@ -3,6 +3,7 @@ package lint
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
 
 	"github.com/yoheimuta/protolint/internal/linter/config"
@@ -38,8 +39,18 @@ func NewCmdLint(
 	if err != nil {
 		return nil, err
 	}
+	if flags.Verbose {
+		if externalConfig != nil {
+			log.Printf("[INFO] protolint loads a config file at %s\n", externalConfig.SourcePath)
+		} else {
+			log.Println("[INFO] protolint doesn't load a config file")
+		}
+	}
+	if externalConfig == nil {
+		externalConfig = &(config.ExternalConfig{})
+	}
 	lintConfig := NewCmdLintConfig(
-		externalConfig,
+		*externalConfig,
 		flags,
 	)
 

--- a/internal/linter/config/externalConfig.go
+++ b/internal/linter/config/externalConfig.go
@@ -11,7 +11,8 @@ type Lint struct {
 
 // ExternalConfig represents the external configuration.
 type ExternalConfig struct {
-	Lint Lint
+	SourcePath string
+	Lint       Lint
 }
 
 // ShouldSkipRule checks whether to skip applying the rule to the file.

--- a/internal/linter/config/externalConfigProvider.go
+++ b/internal/linter/config/externalConfigProvider.go
@@ -21,29 +21,30 @@ const (
 func GetExternalConfig(
 	filePath string,
 	dirPath string,
-) (ExternalConfig, error) {
+) (*ExternalConfig, error) {
 	newPath, err := getExternalConfigPath(filePath, dirPath)
 	if err != nil {
 		if len(filePath) == 0 && len(dirPath) == 0 {
-			return ExternalConfig{}, nil
+			return nil, nil
 		}
-		return ExternalConfig{}, err
+		return nil, err
 	}
 
 	data, err := ioutil.ReadFile(newPath)
 	if err != nil {
-		return ExternalConfig{}, err
+		return nil, err
 	}
 	if len(data) == 0 {
-		return ExternalConfig{}, nil
+		return nil, nil
 	}
 
 	var config ExternalConfig
 	if err := yaml.UnmarshalStrict(data, &config); err != nil {
-		return config, err
+		return nil, err
 	}
+	config.SourcePath = newPath
 
-	return config, nil
+	return &config, nil
 }
 
 func getExternalConfigPath(

--- a/internal/linter/config/externalConfigProvider_test.go
+++ b/internal/linter/config/externalConfigProvider_test.go
@@ -129,6 +129,16 @@ func TestGetExternalConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:         "not found a config file even so inputDirPath is set",
+			inputDirPath: setting_test.TestDataPath("validconfig", "particular_name"),
+			wantExistErr: true,
+		},
+		{
+			name:          "not found a config file even so inputFilePath is set",
+			inputFilePath: setting_test.TestDataPath("validconfig", "particular_name", "not_found.yaml"),
+			wantExistErr:  true,
+		},
 	} {
 		test := test
 		t.Run(test.name, func(t *testing.T) {

--- a/internal/linter/config/externalConfigProvider_test.go
+++ b/internal/linter/config/externalConfigProvider_test.go
@@ -14,7 +14,7 @@ func TestGetExternalConfig(t *testing.T) {
 		name               string
 		inputFilePath      string
 		inputDirPath       string
-		wantExternalConfig config.ExternalConfig
+		wantExternalConfig *config.ExternalConfig
 		wantExistErr       bool
 	}{
 		{
@@ -28,7 +28,8 @@ func TestGetExternalConfig(t *testing.T) {
 		{
 			name:         "valid config file",
 			inputDirPath: setting_test.TestDataPath("validconfig"),
-			wantExternalConfig: config.ExternalConfig{
+			wantExternalConfig: &config.ExternalConfig{
+				SourcePath: setting_test.TestDataPath("validconfig", "protolint.yaml"),
 				Lint: config.Lint{
 					Ignores: []config.Ignore{
 						{
@@ -76,7 +77,8 @@ func TestGetExternalConfig(t *testing.T) {
 		{
 			name:         "load .protolint.yaml",
 			inputDirPath: setting_test.TestDataPath("validconfig", "hidden"),
-			wantExternalConfig: config.ExternalConfig{
+			wantExternalConfig: &config.ExternalConfig{
+				SourcePath: setting_test.TestDataPath("validconfig", "hidden", ".protolint.yaml"),
 				Lint: config.Lint{
 					RulesOption: config.RulesOption{
 						Indent: config.IndentOption{
@@ -90,7 +92,8 @@ func TestGetExternalConfig(t *testing.T) {
 		{
 			name:          "load my_protolint.yaml",
 			inputFilePath: setting_test.TestDataPath("validconfig", "particular_name", "my_protolint.yaml"),
-			wantExternalConfig: config.ExternalConfig{
+			wantExternalConfig: &config.ExternalConfig{
+				SourcePath: setting_test.TestDataPath("validconfig", "particular_name", "my_protolint.yaml"),
 				Lint: config.Lint{
 					RulesOption: config.RulesOption{
 						Indent: config.IndentOption{
@@ -104,7 +107,8 @@ func TestGetExternalConfig(t *testing.T) {
 		{
 			name:         "load protolint.yml",
 			inputDirPath: setting_test.TestDataPath("validconfig", "yml"),
-			wantExternalConfig: config.ExternalConfig{
+			wantExternalConfig: &config.ExternalConfig{
+				SourcePath: setting_test.TestDataPath("validconfig", "yml", "protolint.yml"),
 				Lint: config.Lint{
 					RulesOption: config.RulesOption{
 						Indent: config.IndentOption{
@@ -118,7 +122,8 @@ func TestGetExternalConfig(t *testing.T) {
 		{
 			name:         "load .protolint.yml",
 			inputDirPath: setting_test.TestDataPath("validconfig", "yml_hidden"),
-			wantExternalConfig: config.ExternalConfig{
+			wantExternalConfig: &config.ExternalConfig{
+				SourcePath: setting_test.TestDataPath("validconfig", "yml_hidden", ".protolint.yml"),
 				Lint: config.Lint{
 					RulesOption: config.RulesOption{
 						Indent: config.IndentOption{


### PR DESCRIPTION
ref. [Protolint linting Proto files in node_modules · Issue #155 · yoheimuta/protolint](https://github.com/yoheimuta/protolint/issues/155)