### PR TITLE
Allow a snake_case package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Some rules support a feature that automatically fixed the problems.
 | Yes | IMPORTS_SORTED                    | Verifies that all imports are sorted. The --fix option on the command line can automatically fix some of the problems reported by this rule. |
 | Yes | MESSAGE_NAMES_UPPER_CAMEL_CASE    | Verifies that all message names are CamelCase (with an initial capital). |
 | Yes | ORDER                             | Verifies that all files should be ordered in the specific manner. |
-| Yes | PACKAGE_NAME_LOWER_CASE           | Verifies that the package name only contains lowercase letters, digits and/or periods. |
+| Yes | PACKAGE_NAME_LOWER_CASE           | Verifies that the package name should not contain any lowercase letters. |
 | Yes | RPC_NAMES_UPPER_CAMEL_CASE        | Verifies that all rpc names are CamelCase (with an initial capital).     |
 | Yes | SERVICE_NAMES_UPPER_CAMEL_CASE    | Verifies that all service names are CamelCase (with an initial capital). |
 | Yes | MAX_LINE_LENGTH    | Enforces a maximum line length. The length of a line is defined as the number of Unicode characters in the line. The default is 80 characters. You can configure the detail with `.protolint.yaml`. |

--- a/internal/addon/rules/packageNameLowerCaseRule.go
+++ b/internal/addon/rules/packageNameLowerCaseRule.go
@@ -1,8 +1,6 @@
 package rules
 
 import (
-	"strings"
-
 	"github.com/yoheimuta/go-protoparser/v4/parser"
 
 	"github.com/yoheimuta/protolint/linter/report"
@@ -10,7 +8,7 @@ import (
 	"github.com/yoheimuta/protolint/linter/visitor"
 )
 
-// PackageNameLowerCaseRule verifies that the package name only contains lowercase letters, digits and/or periods.
+// PackageNameLowerCaseRule verifies that the package name doesn't contain any uppercase letters.
 // See https://developers.google.com/protocol-buffers/docs/style#packages.
 type PackageNameLowerCaseRule struct{}
 
@@ -26,7 +24,7 @@ func (r PackageNameLowerCaseRule) ID() string {
 
 // Purpose returns the purpose of this rule.
 func (r PackageNameLowerCaseRule) Purpose() string {
-	return "Verifies that the package name only contains lowercase letters, digits and/or periods."
+	return "Verifies that the package name doesn't contain any uppercase letters."
 }
 
 // IsOfficial decides whether or not this rule belongs to the official guide.
@@ -49,11 +47,11 @@ type packageNameLowerCaseVisitor struct {
 // VisitPackage checks the package.
 func (v *packageNameLowerCaseVisitor) VisitPackage(p *parser.Package) bool {
 	if !isPackageLowerCase(p.Name) {
-		v.AddFailuref(p.Meta.Pos, "Package name %q must only contains lowercase letters, digits and/or periods.", p.Name)
+		v.AddFailuref(p.Meta.Pos, "Package name %q must not contain any uppercase letter.", p.Name)
 	}
 	return false
 }
 
 func isPackageLowerCase(packageName string) bool {
-	return strs.IsLowerCase(strings.Replace(packageName, ".", "", -1))
+	return !strs.HasAnyUpperCase(packageName)
 }

--- a/internal/addon/rules/packageNameLowerCaseRule_test.go
+++ b/internal/addon/rules/packageNameLowerCaseRule_test.go
@@ -75,6 +75,16 @@ func TestPackageNameLowerCaseRule_Apply(t *testing.T) {
 				),
 			},
 		},
+		{
+			name: "no failures for proto with the package name including _",
+			inputProto: &parser.Proto{
+				ProtoBody: []parser.Visitee{
+					&parser.Package{
+						Name: "my.some_service",
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/addon/rules/packageNameLowerCaseRule_test.go
+++ b/internal/addon/rules/packageNameLowerCaseRule_test.go
@@ -71,7 +71,7 @@ func TestPackageNameLowerCaseRule_Apply(t *testing.T) {
 						Column:   10,
 					},
 					"PACKAGE_NAME_LOWER_CASE",
-					`Package name "myV1Package" must only contains lowercase letters, digits and/or periods.`,
+					`Package name "myV1Package" must not contain any uppercase letter.`,
 				),
 			},
 		},

--- a/linter/strs/strs.go
+++ b/linter/strs/strs.go
@@ -81,14 +81,14 @@ func isSnake(s string) bool {
 	return true
 }
 
-// IsLowerCase returns true if s only contain characters in the range a-z0-9.
-func IsLowerCase(s string) bool {
+// HasAnyUpperCase returns true if s contains any of characters in the range A-Z.
+func HasAnyUpperCase(s string) bool {
 	for _, r := range s {
-		if !(isLower(r) || isDigit(r)) {
-			return false
+		if isUpper(r) {
+			return true
 		}
 	}
-	return true
+	return false
 }
 
 // toSnake converts s to snake_case.


### PR DESCRIPTION
ref. [Feature: accept "_" in package names (PACKAGE_NAME_LOWER_CASE) · Issue #153 · yoheimuta/protolint](https://github.com/yoheimuta/protolint/issues/153)