### PR TITLE
Add a new rule named RPC_NAME_CASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Some rules support a feature that automatically fixed the problems.
 | No | SERVICE_NAMES_END_WITH    | Enforces a consistent suffix for service names. You can configure the specific suffix with `.protolint.yaml`. |
 | No | FIELD_NAMES_EXCLUDE_PREPOSITIONS | Verifies that all field names don't include prepositions (e.g. "for", "during", "at"). You can configure the specific prepositions and excluded keywords with `.protolint.yaml`. |
 | No | MESSAGE_NAMES_EXCLUDE_PREPOSITIONS | Verifies that all message names don't include prepositions (e.g. "With", "For"). You can configure the specific prepositions and excluded keywords with `.protolint.yaml`. |
-| No | RPC_NAMES_CASE        | Verifies that all rpc names conform to the specified convention. You can configure the specific convention with `.protolint.yaml`.     |
+| No | RPC_NAMES_CASE        | Verifies that all rpc names conform to the specified convention. You need to configure the specific convention with `.protolint.yaml`.     |
 | No | MESSAGES_HAVE_COMMENT | Verifies that all messages have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
 | No | SERVICES_HAVE_COMMENT | Verifies that all services have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
 | No | RPCS_HAVE_COMMENT | Verifies that all rps have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Some rules support a feature that automatically fixed the problems.
 | No | SERVICE_NAMES_END_WITH    | Enforces a consistent suffix for service names. You can configure the specific suffix with `.protolint.yaml`. |
 | No | FIELD_NAMES_EXCLUDE_PREPOSITIONS | Verifies that all field names don't include prepositions (e.g. "for", "during", "at"). You can configure the specific prepositions and excluded keywords with `.protolint.yaml`. |
 | No | MESSAGE_NAMES_EXCLUDE_PREPOSITIONS | Verifies that all message names don't include prepositions (e.g. "With", "For"). You can configure the specific prepositions and excluded keywords with `.protolint.yaml`. |
+| No | RPC_NAMES_CASE        | Verifies that all rpc names conform to the specified convention. You can configure the specific convention with `.protolint.yaml`.     |
 | No | MESSAGES_HAVE_COMMENT | Verifies that all messages have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
 | No | SERVICES_HAVE_COMMENT | Verifies that all services have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
 | No | RPCS_HAVE_COMMENT | Verifies that all rps have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |

--- a/_example/config/.protolint.yaml
+++ b/_example/config/.protolint.yaml
@@ -57,6 +57,7 @@ lint:
       - ENUMS_HAVE_COMMENT
       - ENUM_FIELDS_HAVE_COMMENT
       - SYNTAX_CONSISTENT
+      - RPC_NAMES_CASE
 
     # The specific linters to remove.
     remove:
@@ -129,6 +130,12 @@ lint:
       # The specific keywords including prepositions to ignore. E.g. EndOfSupport is a term you would like to use, and skip checking.
       excludes:
         - EndOfSupport
+        -
+    #  RPC_NAMES_CASE rule option.
+    rpc_names_case:
+      # The specific convention the name should conforms to.
+      ## Available conventions are "lower_camel_case", "upper_snake_case", or "lower_snake_case".
+      convention: upper_snake_case
 
     # MESSAGES_HAVE_COMMENT rule option.
     messages_have_comment:

--- a/_example/proto/simple.proto
+++ b/_example/proto/simple.proto
@@ -45,4 +45,5 @@ message outer {
 }
 service SearchApi {
     rpc search (SearchRequest) returns (SearchResponse) {};
+    rpc Search (SearchRequest) returns (SearchResponse) {};
 };

--- a/internal/addon/rules/rpcNamesCaseRule.go
+++ b/internal/addon/rules/rpcNamesCaseRule.go
@@ -1,0 +1,65 @@
+package rules
+
+import (
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/protolint/internal/linter/config"
+
+	"github.com/yoheimuta/protolint/linter/report"
+	"github.com/yoheimuta/protolint/linter/strs"
+	"github.com/yoheimuta/protolint/linter/visitor"
+)
+
+// RPCNamesCaseRule verifies that all rpc names conform to the specified convention.
+type RPCNamesCaseRule struct {
+	convention config.ConventionType
+}
+
+// NewRPCNamesCaseRule creates a new RPCNamesCaseRule.
+func NewRPCNamesCaseRule(
+	convention config.ConventionType,
+) RPCNamesCaseRule {
+	return RPCNamesCaseRule{
+		convention: convention,
+	}
+}
+
+// ID returns the ID of this rule.
+func (r RPCNamesCaseRule) ID() string {
+	return "RPC_NAMES_CASE"
+}
+
+// Purpose returns the purpose of this rule.
+func (r RPCNamesCaseRule) Purpose() string {
+	return "Verifies that all rpc names conform to the specified convention."
+}
+
+// IsOfficial decides whether or not this rule belongs to the official guide.
+func (r RPCNamesCaseRule) IsOfficial() bool {
+	return false
+}
+
+// Apply applies the rule to the proto.
+func (r RPCNamesCaseRule) Apply(proto *parser.Proto) ([]report.Failure, error) {
+	v := &rpcNamesCaseVisitor{
+		BaseAddVisitor: visitor.NewBaseAddVisitor(r.ID()),
+		convention:     r.convention,
+	}
+	return visitor.RunVisitor(v, proto, r.ID())
+}
+
+type rpcNamesCaseVisitor struct {
+	*visitor.BaseAddVisitor
+	convention config.ConventionType
+}
+
+// VisitRPC checks the rpc.
+func (v *rpcNamesCaseVisitor) VisitRPC(rpc *parser.RPC) bool {
+	if v.convention == config.ConventionLowerCamel && !strs.IsLowerCamelCase(rpc.RPCName) {
+		v.AddFailuref(rpc.Meta.Pos, "RPC name %q must be LowerCamelCase", rpc.RPCName)
+	} else if v.convention == config.ConventionUpperSnake && !strs.IsUpperSnakeCase(rpc.RPCName) {
+		v.AddFailuref(rpc.Meta.Pos, "RPC name %q must be UpperSnakeCase", rpc.RPCName)
+	} else if v.convention == config.ConventionLowerSnake && !strs.IsLowerSnakeCase(rpc.RPCName) {
+		v.AddFailuref(rpc.Meta.Pos, "RPC name %q must be LowerSnakeCase", rpc.RPCName)
+	}
+	return false
+}

--- a/internal/addon/rules/rpcNamesCaseRule_test.go
+++ b/internal/addon/rules/rpcNamesCaseRule_test.go
@@ -1,0 +1,324 @@
+package rules_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/yoheimuta/protolint/internal/linter/config"
+
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
+	"github.com/yoheimuta/protolint/internal/addon/rules"
+	"github.com/yoheimuta/protolint/linter/report"
+)
+
+func TestRPCNamesCaseRule_Apply(t *testing.T) {
+	tests := []struct {
+		name            string
+		inputProto      *parser.Proto
+		inputConvention config.ConventionType
+		wantFailures    []report.Failure
+	}{
+		{
+			name: "no failures for proto without rpc",
+			inputProto: &parser.Proto{
+				ProtoBody: []parser.Visitee{
+					&parser.Service{},
+				},
+			},
+			inputConvention: config.ConventionLowerCamel,
+		},
+		{
+			name: "no failures for proto with valid rpc",
+			inputProto: &parser.Proto{
+				ProtoBody: []parser.Visitee{
+					&parser.Service{
+						ServiceBody: []parser.Visitee{
+							&parser.RPC{
+								RPCName: "rpcName",
+							},
+						},
+					},
+				},
+			},
+			inputConvention: config.ConventionLowerCamel,
+		},
+		{
+			name: "no failures for proto with valid rpc",
+			inputProto: &parser.Proto{
+				ProtoBody: []parser.Visitee{
+					&parser.Service{
+						ServiceBody: []parser.Visitee{
+							&parser.RPC{
+								RPCName: "RPC_NAME",
+							},
+						},
+					},
+				},
+			},
+			inputConvention: config.ConventionUpperSnake,
+		},
+		{
+			name: "no failures for proto with valid rpc",
+			inputProto: &parser.Proto{
+				ProtoBody: []parser.Visitee{
+					&parser.Service{
+						ServiceBody: []parser.Visitee{
+							&parser.RPC{
+								RPCName: "rpc_name",
+							},
+						},
+					},
+				},
+			},
+			inputConvention: config.ConventionLowerSnake,
+		},
+		{
+			name: "failures for proto with the option of LowerCamelCase",
+			inputProto: &parser.Proto{
+				ProtoBody: []parser.Visitee{
+					&parser.Service{
+						ServiceBody: []parser.Visitee{
+							&parser.RPC{
+								RPCName: "RPCName",
+								Meta: meta.Meta{
+									Pos: meta.Position{
+										Filename: "example.proto",
+										Offset:   100,
+										Line:     5,
+										Column:   10,
+									},
+								},
+							},
+							&parser.RPC{
+								RPCName: "RPC_NAME",
+								Meta: meta.Meta{
+									Pos: meta.Position{
+										Filename: "example.proto",
+										Offset:   200,
+										Line:     10,
+										Column:   20,
+									},
+								},
+							},
+							&parser.RPC{
+								RPCName: "rpc_name",
+								Meta: meta.Meta{
+									Pos: meta.Position{
+										Filename: "example.proto",
+										Offset:   300,
+										Line:     20,
+										Column:   30,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputConvention: config.ConventionLowerCamel,
+			wantFailures: []report.Failure{
+				report.Failuref(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   100,
+						Line:     5,
+						Column:   10,
+					},
+					"RPC_NAMES_CASE",
+					`RPC name "RPCName" must be LowerCamelCase`,
+				),
+				report.Failuref(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   200,
+						Line:     10,
+						Column:   20,
+					},
+					"RPC_NAMES_CASE",
+					`RPC name "RPC_NAME" must be LowerCamelCase`,
+				),
+				report.Failuref(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   300,
+						Line:     20,
+						Column:   30,
+					},
+					"RPC_NAMES_CASE",
+					`RPC name "rpc_name" must be LowerCamelCase`,
+				),
+			},
+		},
+		{
+			name: "failures for proto with the option of UpperSnakeCase",
+			inputProto: &parser.Proto{
+				ProtoBody: []parser.Visitee{
+					&parser.Service{
+						ServiceBody: []parser.Visitee{
+							&parser.RPC{
+								RPCName: "RPCName",
+								Meta: meta.Meta{
+									Pos: meta.Position{
+										Filename: "example.proto",
+										Offset:   100,
+										Line:     5,
+										Column:   10,
+									},
+								},
+							},
+							&parser.RPC{
+								RPCName: "rpcName",
+								Meta: meta.Meta{
+									Pos: meta.Position{
+										Filename: "example.proto",
+										Offset:   200,
+										Line:     10,
+										Column:   20,
+									},
+								},
+							},
+							&parser.RPC{
+								RPCName: "rpc_name",
+								Meta: meta.Meta{
+									Pos: meta.Position{
+										Filename: "example.proto",
+										Offset:   300,
+										Line:     20,
+										Column:   30,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputConvention: config.ConventionUpperSnake,
+			wantFailures: []report.Failure{
+				report.Failuref(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   100,
+						Line:     5,
+						Column:   10,
+					},
+					"RPC_NAMES_CASE",
+					`RPC name "RPCName" must be UpperSnakeCase`,
+				),
+				report.Failuref(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   200,
+						Line:     10,
+						Column:   20,
+					},
+					"RPC_NAMES_CASE",
+					`RPC name "rpcName" must be UpperSnakeCase`,
+				),
+				report.Failuref(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   300,
+						Line:     20,
+						Column:   30,
+					},
+					"RPC_NAMES_CASE",
+					`RPC name "rpc_name" must be UpperSnakeCase`,
+				),
+			},
+		},
+		{
+			name: "failures for proto with the option of LowerSnakeCase",
+			inputProto: &parser.Proto{
+				ProtoBody: []parser.Visitee{
+					&parser.Service{
+						ServiceBody: []parser.Visitee{
+							&parser.RPC{
+								RPCName: "RPCName",
+								Meta: meta.Meta{
+									Pos: meta.Position{
+										Filename: "example.proto",
+										Offset:   100,
+										Line:     5,
+										Column:   10,
+									},
+								},
+							},
+							&parser.RPC{
+								RPCName: "rpcName",
+								Meta: meta.Meta{
+									Pos: meta.Position{
+										Filename: "example.proto",
+										Offset:   200,
+										Line:     10,
+										Column:   20,
+									},
+								},
+							},
+							&parser.RPC{
+								RPCName: "RPC_NAME",
+								Meta: meta.Meta{
+									Pos: meta.Position{
+										Filename: "example.proto",
+										Offset:   300,
+										Line:     20,
+										Column:   30,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			inputConvention: config.ConventionLowerSnake,
+			wantFailures: []report.Failure{
+				report.Failuref(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   100,
+						Line:     5,
+						Column:   10,
+					},
+					"RPC_NAMES_CASE",
+					`RPC name "RPCName" must be LowerSnakeCase`,
+				),
+				report.Failuref(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   200,
+						Line:     10,
+						Column:   20,
+					},
+					"RPC_NAMES_CASE",
+					`RPC name "rpcName" must be LowerSnakeCase`,
+				),
+				report.Failuref(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   300,
+						Line:     20,
+						Column:   30,
+					},
+					"RPC_NAMES_CASE",
+					`RPC name "RPC_NAME" must be LowerSnakeCase`,
+				),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			rule := rules.NewRPCNamesCaseRule(test.inputConvention)
+
+			got, err := rule.Apply(test.inputProto)
+			if err != nil {
+				t.Errorf("got err %v, but want nil", err)
+				return
+			}
+			if !reflect.DeepEqual(got, test.wantFailures) {
+				t.Errorf("got %v, but want %v", got, test.wantFailures)
+			}
+		})
+	}
+}

--- a/internal/cmd/subcmds/rules.go
+++ b/internal/cmd/subcmds/rules.go
@@ -113,6 +113,7 @@ func newAllInternalRules(
 		),
 
 		rules.NewRPCNamesUpperCamelCaseRule(),
+		rules.NewRPCNamesCaseRule(option.RPCNamesCaseOption.Convention),
 		rules.NewRPCsHaveCommentRule(
 			rpcsHaveComment.ShouldFollowGolangStyle,
 		),

--- a/internal/linter/config/rpcNamesCaseOption.go
+++ b/internal/linter/config/rpcNamesCaseOption.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ConventionType is a type of name case convention.
+type ConventionType int
+
+// ConventionType constants.
+const (
+	ConventionLowerCamel ConventionType = iota
+	ConventionUpperSnake
+	ConventionLowerSnake
+)
+
+// RPCNamesCaseOption represents the option for the RPC_NAMES_CASE rule.
+type RPCNamesCaseOption struct {
+	Convention ConventionType
+}
+
+// UnmarshalYAML implements yaml.v2 Unmarshaler interface.
+func (r *RPCNamesCaseOption) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var option struct {
+		Convention string `yaml:"convention"`
+	}
+	if err := unmarshal(&option); err != nil {
+		return err
+	}
+
+	if 0 < len(option.Convention) {
+		supportConventions := map[string]ConventionType{
+			"lower_camel_case": ConventionLowerCamel,
+			"upper_snake_case": ConventionUpperSnake,
+			"lower_snake_case": ConventionLowerSnake,
+		}
+		convention, ok := supportConventions[option.Convention]
+		if !ok {
+			var list []string
+			for k := range supportConventions {
+				list = append(list, k)
+			}
+			return fmt.Errorf("%s is an invalid name convention. valid options are [%s]",
+				option.Convention, strings.Join(list, ","))
+		}
+		r.Convention = convention
+	}
+	return nil
+}

--- a/internal/linter/config/rpcNamesCaseOption.go
+++ b/internal/linter/config/rpcNamesCaseOption.go
@@ -10,7 +10,7 @@ type ConventionType int
 
 // ConventionType constants.
 const (
-	ConventionLowerCamel ConventionType = iota
+	ConventionLowerCamel ConventionType = iota + 1
 	ConventionUpperSnake
 	ConventionLowerSnake
 )

--- a/internal/linter/config/rpcNamesCaseOption_test.go
+++ b/internal/linter/config/rpcNamesCaseOption_test.go
@@ -1,0 +1,79 @@
+package config_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/yoheimuta/protolint/internal/linter/config"
+	"gopkg.in/yaml.v2"
+)
+
+func TestRPCNamesCaseOption_UnmarshalYAML(t *testing.T) {
+	for _, test := range []struct {
+		name                   string
+		inputConfig            []byte
+		wantRPCNamesCaseOption config.RPCNamesCaseOption
+		wantExistErr           bool
+	}{
+		{
+			name: "not found supported convention",
+			inputConfig: []byte(`
+convention: upper_camel_case
+`),
+			wantExistErr: true,
+		},
+		{
+			name: "empty config",
+			inputConfig: []byte(`
+`),
+		},
+		{
+			name: "convention: lower_camel_case",
+			inputConfig: []byte(`
+convention: lower_camel_case
+`),
+			wantRPCNamesCaseOption: config.RPCNamesCaseOption{
+				Convention: config.ConventionLowerCamel,
+			},
+		},
+		{
+			name: "convention: upper_snake_case",
+			inputConfig: []byte(`
+convention: upper_snake_case
+`),
+			wantRPCNamesCaseOption: config.RPCNamesCaseOption{
+				Convention: config.ConventionUpperSnake,
+			},
+		},
+		{
+			name: "convention: lower_snake_case",
+			inputConfig: []byte(`
+convention: lower_snake_case
+`),
+			wantRPCNamesCaseOption: config.RPCNamesCaseOption{
+				Convention: config.ConventionLowerSnake,
+			},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			var got config.RPCNamesCaseOption
+
+			err := yaml.UnmarshalStrict(test.inputConfig, &got)
+			if test.wantExistErr {
+				if err == nil {
+					t.Errorf("got err nil, but want err")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("got err %v, but want nil", err)
+				return
+			}
+
+			if !reflect.DeepEqual(got, test.wantRPCNamesCaseOption) {
+				t.Errorf("got %v, but want %v", got, test.wantRPCNamesCaseOption)
+			}
+		})
+	}
+}

--- a/internal/linter/config/rulesOption.go
+++ b/internal/linter/config/rulesOption.go
@@ -10,6 +10,7 @@ type RulesOption struct {
 	ServiceNamesEndWith             ServiceNamesEndWithOption             `yaml:"service_names_end_with"`
 	FieldNamesExcludePrepositions   FieldNamesExcludePrepositionsOption   `yaml:"field_names_exclude_prepositions"`
 	MessageNamesExcludePrepositions MessageNamesExcludePrepositionsOption `yaml:"message_names_exclude_prepositions"`
+	RPCNamesCaseOption              RPCNamesCaseOption                    `yaml:"rpc_names_case"`
 	MessagesHaveComment             MessagesHaveCommentOption             `yaml:"messages_have_comment"`
 	ServicesHaveComment             ServicesHaveCommentOption             `yaml:"services_have_comment"`
 	RPCsHaveComment                 RPCsHaveCommentOption                 `yaml:"rpcs_have_comment"`

--- a/linter/strs/strs.go
+++ b/linter/strs/strs.go
@@ -15,6 +15,14 @@ func IsUpperCamelCase(s string) bool {
 	return isCamelCase(s)
 }
 
+// IsLowerCamelCase returns true if s is not empty and is camel case without an initial capital.
+func IsLowerCamelCase(s string) bool {
+	if isCapitalized(s) {
+		return false
+	}
+	return isCamelCase(s)
+}
+
 // IsUpperSnakeCase returns true if s only contains uppercase letters,
 // digits, and/or underscores. s MUST NOT begin or end with an underscore.
 func IsUpperSnakeCase(s string) bool {

--- a/linter/strs/strs_test.go
+++ b/linter/strs/strs_test.go
@@ -48,6 +48,46 @@ func TestIsUpperCamelCase(t *testing.T) {
 	}
 }
 
+func TestIsLowerCamelCase(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "the first letter is an uppercase character",
+			input: "Hello",
+		},
+		{
+			name:  "_ is included",
+			input: "hello_world",
+		},
+		{
+			name:  ". is included",
+			input: "hello.world",
+		},
+		{
+			name:  "the first letter is a lowercase character",
+			input: "hello",
+			want:  true,
+		},
+		{
+			name:  "the first letter is a lowercase character and rest is a camel case",
+			input: "helloWorld",
+			want:  true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			got := strs.IsLowerCamelCase(test.input)
+			if got != test.want {
+				t.Errorf("got %v, but want %v", got, test.want)
+			}
+		})
+	}
+}
 func TestIsUpperSnakeCase(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
ref. [Configurable naming conventions · Issue #160 · yoheimuta/protolint](https://github.com/yoheimuta/protolint/issues/160)

I added a new rule, `RPC_NAME_CASE,` in this PR, instead of modifying the existing rule `RPC_NAMES_UPPER_CAMEL_CASE` to accept a new option like `convention.`  
That's because, in the latter, the rule name can contradict the actual behavior controlled by the specified convention. 

Also, I didn't rename `RPC_NAMES_UPPER_CAMEL_CASE` to `RPC_NAMES_CASE` with its default to upper_camel_case.
I feel like it's more beneficial for most users to keep the nearly official best practice to be the first class in this tool.
Besides, I'm not sure it's worth changing with extra effort in a backward compatibility manner.

As a result of these considerations, these two rules result in mutually exclusive. I require users additionally to set a convention in the configuration file to turn `RPC_NAMES_CASE` on. 