### PR TITLE
feat: Add a new rule FILE_HAS_COMMENT

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Some rules support a feature that automatically fixed the problems.
 | No | FIELDS_HAVE_COMMENT | Verifies that all fields have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
 | No | ENUMS_HAVE_COMMENT | Verifies that all enums have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
 | No | ENUM_FIELDS_HAVE_COMMENT | Verifies that all enum fields have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
+| No | FILE_HAS_COMMENT | Verifies that a file starts with a doc comment. |
 | No | SYNTAX_CONSISTENT | Verifies that syntax is a specified version. The default is proto3. You can configure the version with `.protolint.yaml`. |
 
 I recommend that you add `all_default: true` in `.protolint.yaml`, because all linters above are automatically enabled so that you can always enjoy maximum benefits whenever protolint is updated.

--- a/_example/config/.protolint.yaml
+++ b/_example/config/.protolint.yaml
@@ -58,6 +58,7 @@ lint:
       - ENUM_FIELDS_HAVE_COMMENT
       - SYNTAX_CONSISTENT
       - RPC_NAMES_CASE
+      - FILE_HAS_COMMENT
 
     # The specific linters to remove.
     remove:

--- a/internal/addon/rules/fileHasCommentRule.go
+++ b/internal/addon/rules/fileHasCommentRule.go
@@ -1,0 +1,51 @@
+package rules
+
+import (
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/protolint/linter/report"
+	"github.com/yoheimuta/protolint/linter/visitor"
+)
+
+// FileHasCommentRule verifies that a file starts with a doc comment.
+type FileHasCommentRule struct {
+}
+
+// NewFileHasCommentRule creates a new FileHasCommentRule.
+func NewFileHasCommentRule() FileHasCommentRule {
+	return FileHasCommentRule{}
+}
+
+// ID returns the ID of this rule.
+func (r FileHasCommentRule) ID() string {
+	return "FILE_HAS_COMMENT"
+}
+
+// Purpose returns the purpose of this rule.
+func (r FileHasCommentRule) Purpose() string {
+	return "Verifies that a file starts with a doc comment."
+}
+
+// IsOfficial decides whether or not this rule belongs to the official guide.
+func (r FileHasCommentRule) IsOfficial() bool {
+	return false
+}
+
+// Apply applies the rule to the proto.
+func (r FileHasCommentRule) Apply(proto *parser.Proto) ([]report.Failure, error) {
+	v := &fileHasCommentVisitor{
+		BaseAddVisitor: visitor.NewBaseAddVisitor(r.ID()),
+	}
+	return visitor.RunVisitor(v, proto, r.ID())
+}
+
+type fileHasCommentVisitor struct {
+	*visitor.BaseAddVisitor
+}
+
+// VisitSyntax checks the syntax.
+func (v *fileHasCommentVisitor) VisitSyntax(s *parser.Syntax) bool {
+	if !hasComment(s.Comments) {
+		v.AddFailuref(s.Meta.Pos, `File should start with a doc comment`)
+	}
+	return false
+}

--- a/internal/addon/rules/fileHasCommentRule_test.go
+++ b/internal/addon/rules/fileHasCommentRule_test.go
@@ -1,0 +1,79 @@
+package rules_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
+	"github.com/yoheimuta/protolint/internal/addon/rules"
+	"github.com/yoheimuta/protolint/linter/report"
+)
+
+func TestFileHasCommentRule_Apply(t *testing.T) {
+	tests := []struct {
+		name         string
+		inputProto   *parser.Proto
+		wantFailures []report.Failure
+	}{
+		{
+			name: "no failures for proto starting with a doc comment",
+			inputProto: &parser.Proto{
+				ProtoBody: []parser.Visitee{
+					&parser.Syntax{
+						Comments: []*parser.Comment{
+							{
+								Raw: "// this file defines something-something.",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "a failure for proto without any doc comments",
+			inputProto: &parser.Proto{
+				ProtoBody: []parser.Visitee{
+					&parser.Syntax{
+						Meta: meta.Meta{
+							Pos: meta.Position{
+								Filename: "example.proto",
+								Offset:   150,
+								Line:     7,
+								Column:   15,
+							},
+						},
+					},
+				},
+			},
+			wantFailures: []report.Failure{
+				report.Failuref(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   150,
+						Line:     7,
+						Column:   15,
+					},
+					"FILE_HAS_COMMENT",
+					`File should start with a doc comment`,
+				),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			rule := rules.NewFileHasCommentRule()
+
+			got, err := rule.Apply(test.inputProto)
+			if err != nil {
+				t.Errorf("got err %v, but want nil", err)
+				return
+			}
+			if !reflect.DeepEqual(got, test.wantFailures) {
+				t.Errorf("got %v, but want %v", got, test.wantFailures)
+			}
+		})
+	}
+}

--- a/internal/cmd/subcmds/rules.go
+++ b/internal/cmd/subcmds/rules.go
@@ -47,6 +47,7 @@ func newAllInternalRules(
 	repeatedFieldNamesPluralized := option.RepeatedFieldNamesPluralized
 
 	return internalrule.Rules{
+		rules.NewFileHasCommentRule(),
 		rules.NewSyntaxConsistentRule(
 			syntaxConsistent.Version,
 		),


### PR DESCRIPTION
I confirmed it locally.

```
~/protolint ❯❯❯ ./protolint -config_dir_path ./_example/config ./_example/proto
...
[_example/proto/simple.proto:1:1] File should start with a doc comment
...
```