### PR TITLE
feat: Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    # Check for updates once a day
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
+    # Look for a `Dockerfile` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"
+  # - package-ecosystem: "github-actions"
+  #   directory: "/"
+  #   # Check for updates once a week
+  #   schedule:
+  #     interval: "weekly"


### PR DESCRIPTION
This is adding a configuration file to enable dependabot for version updates to gomod and Dockerfile.  The configuration is currently set to check daily for gomod and weekly for Dockerfile but that is easy to change if desired.