### PR TITLE
fix: pass an reference of the struct with lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Jenkins Plugins
 ## Use as a protoc plugin
 
 protolint also maintains a binary [protoc-gen-protolint](cmd/protoc-gen-protolint) that performs the lint functionality as a protoc plugin.
+See [cmd/protoc-gen-protolint/README.md](https://github.com/yoheimuta/protolint/blob/master/cmd/protoc-gen-protolint/README.md) in detail.
 
 This is useful in situations where you already have a protoc plugin workflow.
 

--- a/internal/cmd/protocgenprotolint/cmd.go
+++ b/internal/cmd/protocgenprotolint/cmd.go
@@ -60,7 +60,7 @@ func newSubCmd(
 		return nil, err
 	}
 
-	flags, err := newFlags(req)
+	flags, err := newFlags(&req)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +77,7 @@ func newSubCmd(
 }
 
 func newFlags(
-	req protogen.CodeGeneratorRequest,
+	req *protogen.CodeGeneratorRequest,
 ) (*lint.Flags, error) {
 	flags, err := lint.NewFlags(req.FileToGenerate)
 	if err != nil {


### PR DESCRIPTION
ref. 

- https://github.com/yoheimuta/protolint/pull/184#issuecomment-958604152
- https://medium.com/golangspec/detect-locks-passed-by-value-in-go-efb4ac9a3f2b