### PR TITLE
Refactor fixers

### DIFF
--- a/_example/config/.protolint.yaml
+++ b/_example/config/.protolint.yaml
@@ -79,8 +79,6 @@ lint:
     indent:
       # Available styles are 4(4-spaces), 2(2-spaces) or tab.
       style: 4
-      # Available newlines are "\n", "\r", or "\r\n".
-      newline: "\n"
       # Specifies if it should stop considering and inserting new lines at the appropriate positions
       # when the inner elements are on the same line. Default is false.
       not_insert_newline: true

--- a/_example/config/.protolint.yaml
+++ b/_example/config/.protolint.yaml
@@ -90,11 +90,6 @@ lint:
       excludes:
         - ../proto/invalidFileName.proto
 
-    # IMPORTS_SORTED rule option.
-    imports_sorted:
-      # Available newlines are "\n", "\r", or "\r\n".
-      newline: "\n"
-
     # QUOTE_CONSISTENT rule option.
     quote_consistent:
       # Available quote are "double" or "single".

--- a/internal/addon/rules/importsSortedRule_test.go
+++ b/internal/addon/rules/importsSortedRule_test.go
@@ -111,7 +111,6 @@ func TestImportsSortedRule_Apply(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			rule := rules.NewImportsSortedRule(
-				"\n",
 				false,
 			)
 
@@ -179,7 +178,6 @@ func TestImportsSortedRule_Apply_fix(t *testing.T) {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
 			rule := rules.NewImportsSortedRule(
-				"\n",
 				true,
 			)
 

--- a/internal/addon/rules/indentRule_test.go
+++ b/internal/addon/rules/indentRule_test.go
@@ -224,7 +224,6 @@ Fix https://github.com/yoheimuta/protolint/issues/139`,
 		t.Run(test.name, func(t *testing.T) {
 			rule := rules.NewIndentRule(
 				test.inputStyle,
-				"\n",
 				!test.inputInsertNewline,
 				false,
 			)
@@ -439,7 +438,6 @@ func TestIndentRule_Apply_fix(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			rule := rules.NewIndentRule(
 				space2,
-				"\n",
 				!test.inputInsertNewline,
 				true,
 			)
@@ -476,7 +474,6 @@ func TestIndentRule_Apply_fix(t *testing.T) {
 			// check whether the modified content can pass the lint in the end.
 			ruleOnlyCheck := rules.NewIndentRule(
 				space2,
-				"\n",
 				!test.inputInsertNewline,
 				false,
 			)

--- a/internal/cmd/subcmds/rules.go
+++ b/internal/cmd/subcmds/rules.go
@@ -57,7 +57,6 @@ func newAllInternalRules(
 		rules.NewOrderRule(),
 		rules.NewIndentRule(
 			indent.Style,
-			indent.Newline,
 			indent.NotInsertNewline,
 			fixMode,
 		),

--- a/internal/cmd/subcmds/rules.go
+++ b/internal/cmd/subcmds/rules.go
@@ -34,7 +34,6 @@ func newAllInternalRules(
 	indent := option.Indent
 	maxLineLength := option.MaxLineLength
 	enumFieldNamesZeroValueEndWith := option.EnumFieldNamesZeroValueEndWith
-	importsSorted := option.ImportsSorted
 	serviceNamesEndWith := option.ServiceNamesEndWith
 	fieldNamesExcludePrepositions := option.FieldNamesExcludePrepositions
 	messageNamesExcludePrepositions := option.MessageNamesExcludePrepositions
@@ -70,7 +69,6 @@ func newAllInternalRules(
 		rules.NewPackageNameLowerCaseRule(),
 
 		rules.NewImportsSortedRule(
-			importsSorted.Newline,
 			fixMode,
 		),
 

--- a/internal/linter/config/importsSortedOption.go
+++ b/internal/linter/config/importsSortedOption.go
@@ -6,6 +6,7 @@ import (
 
 // ImportsSortedOption represents the option for the IMPORTS_SORTED rule.
 type ImportsSortedOption struct {
+	// Deprecated: not used
 	Newline string
 }
 

--- a/internal/linter/config/indentOption.go
+++ b/internal/linter/config/indentOption.go
@@ -7,7 +7,8 @@ import (
 
 // IndentOption represents the option for the INDENT rule.
 type IndentOption struct {
-	Style            string
+	Style string
+	// Deprecated: not used
 	Newline          string
 	NotInsertNewline bool
 }

--- a/linter/fixer/fixer.go
+++ b/linter/fixer/fixer.go
@@ -13,6 +13,7 @@ import (
 type Fixer interface {
 	// NOTE: This method is insufficient to process unexpected multi-line contents.
 	ReplaceText(line int, old, new string)
+	ReplaceAll(proc func(lines []string) []string)
 }
 
 // Fixing adds the way to modify the proto file to Fixer.
@@ -65,6 +66,13 @@ func (f *BaseFixing) ReplaceText(line int, old, new string) {
 	f.content = []byte(strings.Join(lines, f.lineEnding))
 }
 
+// ReplaceAll replaces the lines.
+func (f *BaseFixing) ReplaceAll(proc func(lines []string) []string) {
+	lines := strings.Split(string(f.content), f.lineEnding)
+	lines = proc(lines)
+	f.content = []byte(strings.Join(lines, f.lineEnding))
+}
+
 // Finally writes the fixed content to the file.
 func (f *BaseFixing) Finally() error {
 	return osutil.WriteExistingFile(f.fileName, f.content)
@@ -75,6 +83,9 @@ type NopFixing struct{}
 
 // ReplaceText noop
 func (f NopFixing) ReplaceText(line int, old, new string) {}
+
+// ReplaceAll noop
+func (f NopFixing) ReplaceAll(proc func(lines []string) []string) {}
 
 // Finally noop
 func (f NopFixing) Finally() error { return nil }


### PR DESCRIPTION
This refactoring allows users to go without specifying newline in yaml config.
It results in the newline field of importsSortedRule and indentRule deprecated.