### PR TITLE
feat: Signal proto3 optional support

### DIFF
--- a/internal/cmd/protocgenprotolint/cmd.go
+++ b/internal/cmd/protocgenprotolint/cmd.go
@@ -3,11 +3,12 @@ package protocgenprotolint
 import (
 	"bytes"
 	"fmt"
-	"google.golang.org/protobuf/types/pluginpb"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
+
+	"google.golang.org/protobuf/types/pluginpb"
 
 	"github.com/yoheimuta/protolint/internal/cmd/subcmds"
 

--- a/internal/cmd/protocgenprotolint/cmd.go
+++ b/internal/cmd/protocgenprotolint/cmd.go
@@ -1,9 +1,12 @@
 package protocgenprotolint
 
 import (
+	"bytes"
 	"fmt"
+	"google.golang.org/protobuf/types/pluginpb"
 	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/yoheimuta/protolint/internal/cmd/subcmds"
@@ -36,12 +39,36 @@ func Do(
 		return doVersion(stdout)
 	}
 
+	err := signalSupportProto3Optional()
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, err)
+		return osutil.ExitInternalFailure
+	}
+
 	subCmd, err := newSubCmd(stdin, stdout, stderr)
 	if err != nil {
 		_, _ = fmt.Fprintln(stderr, err)
 		return osutil.ExitInternalFailure
 	}
 	return subCmd.Run()
+}
+
+func signalSupportProto3Optional() error {
+	// supports proto3 field presence
+	// See https://github.com/protocolbuffers/protobuf/blob/cdc11c2d2d314ce0382fe0eaa715e5e0e1270438/docs/implementing_proto3_presence.md#signaling-that-your-code-generator-supports-proto3-optional
+	var supportedFeatures = uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
+	data, err := proto.Marshal(&protogen.CodeGeneratorResponse{
+		SupportedFeatures: &supportedFeatures,
+	})
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(os.Stdout, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func newSubCmd(


### PR DESCRIPTION
ref. https://github.com/yoheimuta/protolint/issues/234

I checked the support locally as below.

```
(base) ❯ cat test.proto
syntax = "proto3";

package test;

message Test {
  optional string foo = 1;
}
(base) ❯ protoc --protolint_out=. test.proto
```

```
(base) ❯ cat test3.proto
syntax = "proto3";

package test;

message testTest {
  optional string foo = 1;
}
(base) ❯ protoc --protolint_out=. test3.proto
[test3.proto:5:1] Message name "testTest" must be UpperCamelCase like "TestTest"
--protolint_out: protoc-gen-protolint: Plugin failed with status code 1.
```