### PR TITLE
fix: Clean up plugin clients by registering them to managedClients

### DIFF
--- a/internal/cmd/subcmds/lint/cmdLint.go
+++ b/internal/cmd/subcmds/lint/cmdLint.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/hashicorp/go-plugin"
+
 	"github.com/yoheimuta/go-protoparser/v4/parser"
 
 	"github.com/yoheimuta/protolint/internal/linter/config"
@@ -77,6 +79,8 @@ func NewCmdLint(
 
 // Run lints to proto files.
 func (c *CmdLint) Run() osutil.ExitCode {
+	defer plugin.CleanupClients()
+
 	failures, err := c.run()
 	if err != nil {
 		_, _ = fmt.Fprintln(c.stderr, err)

--- a/internal/cmd/subcmds/pluginFlag.go
+++ b/internal/cmd/subcmds/pluginFlag.go
@@ -49,6 +49,8 @@ func (f *PluginFlag) BuildPlugins(verbose bool) ([]shared.RuleSet, error) {
 				Level:  level,
 				Name:   "plugin",
 			}),
+			// To cleanup. See. https://github.com/yoheimuta/protolint/issues/237
+			Managed: true,
 		})
 
 		rpcClient, err := client.Client()


### PR DESCRIPTION
ref. https://github.com/yoheimuta/protolint/issues/237

I confirmed it locally that no process was lingering after the parent exit.

```
(base) ❯ ./protolint -plugin ./plugin_example ./_example/proto/
(base) ❯ ps aux | grep plugin
yoheimuta        36711   0.0  0.0  4399420    772 s047  S+    6:46PM   0:00.00 grep --color plugin
```