### PR TITLE
dev: Build and publish multi arch docker images

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,20 @@ builds:
       - windows
       - darwin
       - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 6
+      - 7
+    ignore:
+      - goos: windows
+        goarch: arm
+        goarm: 6
+      - goos: windows
+        goarch: arm
+        goarm: 7
     ldflags:
       - -s -w -X github.com/yoheimuta/protolint/internal/cmd.version={{.Version}} -X github.com/yoheimuta/protolint/internal/cmd.revision={{.ShortCommit}}  # yamllint disable-line rule:line-length
   -
@@ -25,6 +39,20 @@ builds:
       - windows
       - darwin
       - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+    goarm:
+      - 6
+      - 7
+    ignore:
+      - goos: windows
+        goarch: arm
+        goarm: 6
+      - goos: windows
+        goarch: arm
+        goarm: 7
     ldflags:
       - -s -w -X github.com/yoheimuta/protolint/internal/cmd/protocgenprotolint.version={{.Version}} -X github.com/yoheimuta/protolint/internal/cmd/protocgenprotolint.revision={{.ShortCommit}}  # yamllint disable-line rule:line-length
 archives:
@@ -64,7 +92,69 @@ brews:
       bin.install "protolint"
       bin.install "protoc-gen-protolint"
       prefix.install "LICENSE"
+docker_manifests:
+  # https://goreleaser.com/customization/docker_manifest/
+  - name_template: yoheimuta/{{ .ProjectName }}:{{ .Version }}
+    image_templates:
+      - yoheimuta/{{ .ProjectName }}:{{ .Tag }}-amd64
+      - yoheimuta/{{ .ProjectName }}:{{ .Tag }}-arm64v8
+      - yoheimuta/{{ .ProjectName }}:{{ .Tag }}-armv6
+      - yoheimuta/{{ .ProjectName }}:{{ .Tag }}-armv7
+  - name_template: yoheimuta/{{ .ProjectName }}:latest
+    image_templates:
+      - yoheimuta/{{ .ProjectName }}:latest-amd64
+      - yoheimuta/{{ .ProjectName }}:latest-arm64v8
+      - yoheimuta/{{ .ProjectName }}:latest-armv6
+      - yoheimuta/{{ .ProjectName }}:latest-armv7
 dockers:
-  - image_templates:
-      - yoheimuta/protolint:{{ .Tag }}
-      - yoheimuta/protolint:latest
+  # https://goreleaser.com/customization/docker/
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "yoheimuta/{{ .ProjectName }}:{{ .Tag }}-amd64"
+      - "yoheimuta/{{ .ProjectName }}:latest-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "yoheimuta/{{ .ProjectName }}:{{ .Tag }}-arm64v8"
+      - "yoheimuta/{{ .ProjectName }}:latest-arm64v8"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 6
+    image_templates:
+      - "yoheimuta/{{ .ProjectName }}:{{ .Tag }}-armv6"
+      - "yoheimuta/{{ .ProjectName }}:latest-armv6"
+    build_flag_templates:
+      - "--platform=linux/arm/v6"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+  - use: buildx
+    goos: linux
+    goarch: arm
+    goarm: 7
+    image_templates:
+      - "yoheimuta/{{ .ProjectName }}:{{ .Tag }}-armv7"
+      - "yoheimuta/{{ .ProjectName }}:latest-armv7"
+    build_flag_templates:
+      - "--platform=linux/arm/v7"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -112,49 +112,49 @@ dockers:
     goos: linux
     goarch: amd64
     image_templates:
-      - "yoheimuta/{{ .ProjectName }}:{{ .Tag }}-amd64"
-      - "yoheimuta/{{ .ProjectName }}:latest-amd64"
+      - yoheimuta/{{ .ProjectName }}:{{ .Tag }}-amd64
+      - yoheimuta/{{ .ProjectName }}:latest-amd64
     build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
+      - --platform=linux/amd64
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.title={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
   - use: buildx
     goos: linux
     goarch: arm64
     image_templates:
-      - "yoheimuta/{{ .ProjectName }}:{{ .Tag }}-arm64v8"
-      - "yoheimuta/{{ .ProjectName }}:latest-arm64v8"
+      - yoheimuta/{{ .ProjectName }}:{{ .Tag }}-arm64v8
+      - yoheimuta/{{ .ProjectName }}:latest-arm64v8
     build_flag_templates:
-      - "--platform=linux/arm64/v8"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
+      - --platform=linux/arm64/v8
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.title={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
   - use: buildx
     goos: linux
     goarch: arm
     goarm: 6
     image_templates:
-      - "yoheimuta/{{ .ProjectName }}:{{ .Tag }}-armv6"
-      - "yoheimuta/{{ .ProjectName }}:latest-armv6"
+      - yoheimuta/{{ .ProjectName }}:{{ .Tag }}-armv6
+      - yoheimuta/{{ .ProjectName }}:latest-armv6
     build_flag_templates:
-      - "--platform=linux/arm/v6"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
+      - --platform=linux/arm/v6
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.title={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}
   - use: buildx
     goos: linux
     goarch: arm
     goarm: 7
     image_templates:
-      - "yoheimuta/{{ .ProjectName }}:{{ .Tag }}-armv7"
-      - "yoheimuta/{{ .ProjectName }}:latest-armv7"
+      - yoheimuta/{{ .ProjectName }}:{{ .Tag }}-armv7
+      - yoheimuta/{{ .ProjectName }}:latest-armv7
     build_flag_templates:
-      - "--platform=linux/arm/v7"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
+      - --platform=linux/arm/v7
+      - --label=org.opencontainers.image.created={{.Date}}
+      - --label=org.opencontainers.image.title={{.ProjectName}}
+      - --label=org.opencontainers.image.revision={{.FullCommit}}
+      - --label=org.opencontainers.image.version={{.Version}}


### PR DESCRIPTION
ref. https://github.com/yoheimuta/protolint/issues/251

Confirmed locally.

```
(base) ❯ goreleaser release --snapshot --skip-publish --rm-dist
   • releasing...
   • loading config file       file=.goreleaser.yml
   • loading environment variables
   • getting and validating git state
      • building...               commit=b0681c8edea6caf8392ac7e954a76a3043dc19d0 latest tag=v0.38.2
      • pipe skipped              error=disabled during snapshot mode
   • parsing tag
   • running before hooks
      • running                   hook=go mod download
   • setting defaults
      • snapshotting
      • github/gitlab/gitea releases
      • project name
      • loading go mod information
      • building binaries
      • creating source archive
      • archives
      • linux packages
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • signing docker images
      • docker images
      • docker manifests
      • artifactory
      • blobs
      • homebrew tap formula
      • scoop manifests
      • twitter
      • reddit
      • slack
      • milestones
   • snapshotting
      • building snapshot...      version=v0.38.2-next
   • checking ./dist
      • --rm-dist is set, cleaning it up
   • loading go mod information
   • writing effective config file
      • writing                   config=dist/config.yaml
   • generating changelog
      • pipe skipped              error=not available for snapshots
   • building binaries
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protolint_darwin_arm64/protolint
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protolint_linux_arm64/protolint
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protolint_linux_amd64/protolint
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protolint_windows_arm64/protolint.exe
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protolint_linux_arm_6/protolint
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protolint_linux_arm_7/protolint
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protolint_darwin_amd64/protolint
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protolint_windows_amd64/protolint.exe
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protoc-gen-protolint_linux_arm64/protoc-gen-protolint
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protoc-gen-protolint_linux_amd64/protoc-gen-protolint
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protoc-gen-protolint_darwin_arm64/protoc-gen-protolint
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protoc-gen-protolint_linux_arm_7/protoc-gen-protolint
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protoc-gen-protolint_darwin_amd64/protoc-gen-protolint
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protoc-gen-protolint_windows_amd64/protoc-gen-protolint.exe
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protoc-gen-protolint_windows_arm64/protoc-gen-protolint.exe
      • building                  binary=/Users/yoheimuta/write/program_tmp/go/src/github.com/yoheimuta/protolint/dist/protoc-gen-protolint_linux_arm_6/protoc-gen-protolint
   • archives
      • creating                  archive=dist/protolint_v0.38.2-next_Darwin_x86_64.tar.gz
      • creating                  archive=dist/protolint_v0.38.2-next_Windows_x86_64.tar.gz
      • creating                  archive=dist/protolint_v0.38.2-next_Linux_arm64.tar.gz
      • creating                  archive=dist/protolint_v0.38.2-next_Linux_x86_64.tar.gz
      • creating                  archive=dist/protolint_v0.38.2-next_Darwin_arm64.tar.gz
      • creating                  archive=dist/protolint_v0.38.2-next_Linux_armv7.tar.gz
      • creating                  archive=dist/protolint_v0.38.2-next_Windows_arm64.tar.gz
      • creating                  archive=dist/protolint_v0.38.2-next_Linux_armv6.tar.gz
   • creating source archive
   • linux packages
   • snapcraft packages
   • calculating checksums
      • checksumming              file=protolint_v0.38.2-next_Darwin_x86_64.tar.gz
      • checksumming              file=protolint_v0.38.2-next_Windows_x86_64.tar.gz
      • checksumming              file=protolint_v0.38.2-next_Windows_arm64.tar.gz
      • checksumming              file=protolint_v0.38.2-next_Linux_armv6.tar.gz
      • checksumming              file=protolint_v0.38.2-next_Linux_x86_64.tar.gz
      • checksumming              file=protolint_v0.38.2-next_Linux_arm64.tar.gz
      • checksumming              file=protolint_v0.38.2-next_Linux_armv7.tar.gz
      • checksumming              file=protolint_v0.38.2-next_Darwin_arm64.tar.gz
   • signing artifacts
   • docker images
      • building docker image     image=yoheimuta/protolint:v0.38.2-armv6
      • building docker image     image=yoheimuta/protolint:v0.38.2-amd64
      • building docker image     image=yoheimuta/protolint:v0.38.2-arm64v8
      • building docker image     image=yoheimuta/protolint:v0.38.2-armv7
      • pipe skipped              error=publishing is disabled
   • publishing
      • blobs
      • http upload
      • custom publisher
      • artifactory
      • docker images
         • pipe skipped              error=publishing is disabled
      • docker manifests
         • pipe skipped              error=publishing is disabled
      • snapcraft packages
         • pipe skipped              error=publishing is disabled
      • github/gitlab/gitea releases
         • pipe skipped              error=publishing is disabled
      • homebrew tap formula
         • writing                   formula=dist/protolint.rb
         • pipe skipped              error=publishing is disabled
      • scoop manifests
      • milestones
         • pipe skipped              error=publishing is disabled
   • signing docker images
      • pipe skipped              error=artifact signing is disabled
   • announcing
      • twitter
         • pipe skipped              error=announcing is disabled
      • reddit
         • pipe skipped              error=announcing is disabled
      • slack
         • pipe skipped              error=announcing is disabled
   • release succeeded after 48.06s
```

```
(base) ❯ docker images
REPOSITORY                                      TAG                       IMAGE ID       CREATED          SIZE
yoheimuta/protolint                             latest-armv6              54d317342e5e   49 seconds ago   19MB
yoheimuta/protolint                             v0.38.2-armv6             54d317342e5e   49 seconds ago   19MB
yoheimuta/protolint                             latest-armv7              bfcb8d7b0ae7   50 seconds ago   17.3MB
yoheimuta/protolint                             v0.38.2-armv7             bfcb8d7b0ae7   50 seconds ago   17.3MB
yoheimuta/protolint                             latest-arm64v8            a3b15f10177f   51 seconds ago   20.3MB
yoheimuta/protolint                             v0.38.2-arm64v8           a3b15f10177f   51 seconds ago   20.3MB
yoheimuta/protolint                             latest-amd64              489bef82f909   55 seconds ago   21.2MB
yoheimuta/protolint                             v0.38.2-amd64             489bef82f909   55 seconds ago   21.2MB
...
```

```
(base) ❯ docker run --volume "$(pwd):/workspace" --workdir /workspace yoheimuta/protolint:v0.38.2-amd64 version
protolint version v0.38.2-next(b0681c8)

(base) ❯ docker run --volume "$(pwd):/workspace" --workdir /workspace yoheimuta/protolint:v0.38.2-arm64v8 version
WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64) and no specific platform was requested
protolint version v0.38.2-next(b0681c8)
```