### PR TITLE
Set up QEMU to fix exec format error

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           go-version: 1.17
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
         name: Docker Login
         uses: docker/login-action@v1.14.1
         with:


### PR DESCRIPTION
ref. 

- https://github.com/yoheimuta/protolint/runs/7053095562?check_suite_focus=true
- https://github.com/yoheimuta/protolint/issues/251

```
#7 [2/3] RUN apk -U --no-cache upgrade; /bin/rm -rf /var/cache/apk/*
#0 0.215 standard_init_linux.go:228: exec user process caused: exec format error
#7 ERROR: executor failed running [/bin/sh -c apk -U --no-cache upgrade; /bin/rm -rf /var/cache/apk/*]: exit code: 1
------
 > [2/3] RUN apk -U --no-cache upgrade; /bin/rm -rf /var/cache/apk/*:
#0 0.215 standard_init_linux.go:228: exec user process caused: exec format error
------
error: failed to solve: executor failed running [/bin/sh -c apk -U --no-cache upgrade; /bin/rm -rf /var/cache/apk/*]: exit code: 1
```