### PR TITLE
Fix some minors of https://github.com/yoheimuta/protolint/pull/261

### DIFF
--- a/_proto/plugin.proto
+++ b/_proto/plugin.proto
@@ -1,8 +1,5 @@
 syntax = "proto3";
 package proto;
-enum foo {
-	TestEnum = 1;
-}
 
 service RuleSetService {
   rpc ListRules(ListRulesRequest) returns (ListRulesResponse);

--- a/internal/cmd/subcmds/list/cmdList.go
+++ b/internal/cmd/subcmds/list/cmdList.go
@@ -2,8 +2,9 @@ package list
 
 import (
 	"fmt"
-	"github.com/yoheimuta/protolint/internal/addon/plugin/shared"
 	"io"
+
+	"github.com/yoheimuta/protolint/internal/addon/plugin/shared"
 
 	"github.com/yoheimuta/protolint/internal/linter/config"
 

--- a/internal/cmd/subcmds/list/flags.go
+++ b/internal/cmd/subcmds/list/flags.go
@@ -6,18 +6,13 @@ import (
 	"github.com/yoheimuta/protolint/internal/cmd/subcmds"
 
 	"github.com/yoheimuta/protolint/internal/addon/plugin/shared"
-
-	"github.com/yoheimuta/protolint/internal/linter/report/reporters"
-
-	"github.com/yoheimuta/protolint/internal/linter/report"
 )
 
 // Flags represents a set of lint flag parameters.
 type Flags struct {
 	*flag.FlagSet
 
-	Reporter report.Reporter
-	Plugins  []shared.RuleSet
+	Plugins []shared.RuleSet
 }
 
 // NewFlags creates a new Flags.
@@ -25,8 +20,7 @@ func NewFlags(
 	args []string,
 ) (Flags, error) {
 	f := Flags{
-		FlagSet:  flag.NewFlagSet("lint", flag.ExitOnError),
-		Reporter: reporters.PlainReporter{},
+		FlagSet: flag.NewFlagSet("list", flag.ExitOnError),
 	}
 	var pf subcmds.PluginFlag
 


### PR DESCRIPTION
ref. https://github.com/yoheimuta/protolint/pull/261

```
(base) ❯ ./protolint list -plugin ./plugin_example
...
# These two rules come from the plugin.
ENUM_NAMES_LOWER_SNAKE_CASE: Verifies that all enum names are LowerSnakeCase.
SIMPLE: Simple custom rule.
```