### PR TITLE
Change from container-scan to trivy

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -57,7 +57,7 @@ jobs:
         uses: github/codeql-action/autobuild@v2
 
       # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 https://git.io/JvXDl
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
       # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
       #    and modify them (or add more) to build your code if your project

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,15 +34,15 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: 'docker.io/yoheimuta/protolint:${{ github.sha }}'
-          format: 'sarif'
+          image-ref: docker.io/yoheimuta/protolint:${{ github.sha }}
+          format: sarif
           ignore-unfixed: true
-          output: 'trivy-results.sarif'
+          output: trivy-results.sarif
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         with:
-          sarif_file: 'trivy-results.sarif'
+          sarif_file: trivy-results.sarif
 
       - uses: hadolint/hadolint-action@v2.1.0
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -41,6 +41,7 @@ jobs:
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
+        if: always()
         with:
           sarif_file: trivy-results.sarif
           wait-for-processing: true
@@ -54,6 +55,7 @@ jobs:
 
       - name: Upload Hadolint scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
+        if: always()
         with:
           sarif_file: hadolint-results.sarif
           wait-for-processing: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,7 +43,17 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: trivy-results.sarif
+          wait-for-processing: true
 
       - uses: hadolint/hadolint-action@v2.1.0
         with:
           dockerfile: Dockerfile
+          failure-threshold: style
+          format: sarif
+          output-file: hadolint-results.sarif
+
+      - name: Upload Hadolint scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: hadolint-results.sarif
+          wait-for-processing: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -35,6 +35,7 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: docker.io/yoheimuta/protolint:${{ github.sha }}
+          exit-code: '1'
           format: sarif
           ignore-unfixed: true
           output: trivy-results.sarif

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,13 +31,18 @@ jobs:
       - name: Build Docker image
         run: docker build -t docker.io/yoheimuta/protolint:${{ github.sha }} .
 
-      # Skip this fail step for now. See https://github.com/yoheimuta/protolint/issues/259
-      #- name: Container image scan
-      #  uses: Azure/container-scan@v0.1
-      #  with:
-          # Docker image to scan
-      #    image-name: docker.io/yoheimuta/protolint:${{ github.sha }}
-      #    severity-threshold: LOW  # optional, default is HIGH
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'docker.io/yoheimuta/protolint:${{ github.sha }}'
+          format: 'sarif'
+          ignore-unfixed: true
+          output: 'trivy-results.sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'
 
       - uses: hadolint/hadolint-action@v2.1.0
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
         run: docker build -t docker.io/yoheimuta/protolint:${{ github.sha }} .
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.6.2
         with:
           image-ref: docker.io/yoheimuta/protolint:${{ github.sha }}
           exit-code: '1'


### PR DESCRIPTION
The container-scan action is running trivy and dockle.  This repository is already running the hadolint action and dockle doesn't have a github action, so I think it's ok to skip dockle and just run trivy instead.

You might need to enable Code Scanning on the project Code Security and Analysis settings if you haven't already done that. https://github.com/yoheimuta/protolint/settings/security_analysis should be the link to get there I hope.
I used the config example from https://github.com/aquasecurity/trivy-action#using-trivy-with-github-code-scanning and we have already enabled the CodeQL scanning in .github/workflow.

This article https://medium.com/pvs-studio/how-to-get-nice-error-reports-using-sarif-in-github-68df5d4ff335 seems to give a good overview on viewing SARIF results in github.

Fixes #259 
Fixes #199 