### PR TITLE
fix: run workflows only on pull_request

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,6 @@
 name: Go
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,7 +2,6 @@
 name: Shellcheck
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -2,7 +2,6 @@
 name: yamllint
 
 on:
-  push:
   pull_request:
 
 jobs:


### PR DESCRIPTION
`codeql-action/upload-sarif` action doesn't run on regular push trigger.

Removing the push trigger will also remove the duplicate workflow runs when a pull request is opened.