### PR TITLE
Add --auto_disable=[next|this] flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@
 [![License](http://img.shields.io/:license-mit-blue.svg)](https://github.com/yoheimuta/protolint/blob/master/LICENSE)
 [![Docker](https://img.shields.io/docker/pulls/yoheimuta/protolint)](https://hub.docker.com/r/yoheimuta/protolint)
 
-protolint is the pluggable linting utility for Protocol Buffer files (proto2+proto3):
+protolint is the pluggable linting/fixing utility for Protocol Buffer files (proto2+proto3):
 
 - Runs fast because this works without compiler.
 - Easy to follow the official style guide. The rules and the style guide correspond to each other exactly.
+  - Fixer automatically fixes all the possible official style guide violations.
 - Allows to disable rules with a comment in a Protocol Buffer file.
   - It is useful for projects which must keep API compatibility while enforce the style guide as much as possible.
+  - Some rules can be automatically disabled by inserting comments to the spotted violations.
 - Loads plugins to contain your custom lint rules.
 - Undergone testing for all rules.
 - Many integration supports.
@@ -73,6 +75,8 @@ protolint .                                 # same as "protolint lint ."
 protolint lint -config_path=path/to/your_protolint.yaml . # use path/to/your_protolint.yaml
 protolint lint -config_dir_path=path/to .   # search path/to for .protolint.yaml
 protolint lint -fix .                       # automatically fix some of the problems reported by some rules
+protolint lint -fix -auto_disable=next .    # automatically fix some problems and insert disable comments to the other problems. The available values are next and this.
+protolint lint -auto_disable=next .         # automatically insert disable comments to the other problems. 
 protolint lint -v .                         # with verbose output to investigate the parsing error
 protolint lint -no-error-on-unmatched-pattern . # exits with success code even if no file is found (file & directory mode)
 protolint lint -reporter junit .            # output results in JUnit XML format
@@ -151,41 +155,45 @@ The rule set follows:
 - [Official Style Guide](https://developers.google.com/protocol-buffers/docs/style). This is enabled by default. Basically, these rules can fix the violations by appending `-fix` option.
 - Unofficial Style Guide. This is disabled by default. You can enable each rule with `.protolint.yaml`.
 
-The `-fix` option on the command line can automatically fix some of the problems reported by fixable rules.
+The `-fix` option on the command line can automatically fix all the problems reported by fixable rules.
 See Fixable columns below.
 
-| Official | Fixable | ID                                | Purpose                                                                  |
-|----------|---------|-----------------------------------|--------------------------------------------------------------------------|
-| Yes | ✅ | ENUM_FIELD_NAMES_PREFIX | Verifies that enum field names are prefixed with its ENUM_NAME_UPPER_SNAKE_CASE.        |
-| Yes | ✅ | ENUM_FIELD_NAMES_UPPER_SNAKE_CASE | Verifies that all enum field names are CAPITALS_WITH_UNDERSCORES.        |
-| Yes | ✅ | ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH | Verifies that the zero value enum should have the suffix (e.g. "UNSPECIFIED", "INVALID"). The default is "UNSPECIFIED". You can configure the specific suffix with `.protolint.yaml`. |
-| Yes | ✅ | ENUM_NAMES_UPPER_CAMEL_CASE       | Verifies that all enum names are CamelCase (with an initial capital).    |
-| Yes | ✅ | FILE_NAMES_LOWER_SNAKE_CASE       | Verifies that all file names are lower_snake_case.proto. You can configure the excluded files with `.protolint.yaml`. |
-| Yes | ✅ | FIELD_NAMES_LOWER_SNAKE_CASE      | Verifies that all field names are underscore_separated_names.            |
-| Yes | ✅ | IMPORTS_SORTED                    | Verifies that all imports are sorted. |
-| Yes | ✅ | MESSAGE_NAMES_UPPER_CAMEL_CASE    | Verifies that all message names are CamelCase (with an initial capital). |
-| Yes | ✅ | ORDER                             | Verifies that all files should be ordered in the specific manner. |
-| Yes | ✅ | PACKAGE_NAME_LOWER_CASE           | Verifies that the package name should not contain any lowercase letters. |
-| Yes | ✅ | RPC_NAMES_UPPER_CAMEL_CASE        | Verifies that all rpc names are CamelCase (with an initial capital).     |
-| Yes | ✅ | SERVICE_NAMES_UPPER_CAMEL_CASE    | Verifies that all service names are CamelCase (with an initial capital). |
-| Yes | ✅ | REPEATED_FIELD_NAMES_PLURALIZED   | Verifies that repeated field names are pluralized names.            |
-| Yes | ✅ | QUOTE_CONSISTENT   | Verifies that the use of quote for strings is consistent. The default is double quoted. You can configure the specific quote with `.protolint.yaml`.          |
-| Yes | ✅ | INDENT    | Enforces a consistent indentation style. The default style is 2 spaces. Inserting appropriate new lines is also forced by default. You can configure the detail with `.protolint.yaml`. |
-| Yes | ✅ | PROTO3_FIELDS_AVOID_REQUIRED      | Verifies that all fields should avoid required for proto3.            |
-| Yes | _  | PROTO3_GROUPS_AVOID      | Verifies that all groups should be avoided for proto3.            |
-| Yes | _  | MAX_LINE_LENGTH    | Enforces a maximum line length. The length of a line is defined as the number of Unicode characters in the line. The default is 80 characters. You can configure the detail with `.protolint.yaml`. |
-| No | _  | SERVICE_NAMES_END_WITH    | Enforces a consistent suffix for service names. You can configure the specific suffix with `.protolint.yaml`. |
-| No | _  | FIELD_NAMES_EXCLUDE_PREPOSITIONS | Verifies that all field names don't include prepositions (e.g. "for", "during", "at"). You can configure the specific prepositions and excluded keywords with `.protolint.yaml`. |
-| No | _  | MESSAGE_NAMES_EXCLUDE_PREPOSITIONS | Verifies that all message names don't include prepositions (e.g. "With", "For"). You can configure the specific prepositions and excluded keywords with `.protolint.yaml`. |
-| No | _  | RPC_NAMES_CASE        | Verifies that all rpc names conform to the specified convention. You need to configure the specific convention with `.protolint.yaml`.     |
-| No | _  | MESSAGES_HAVE_COMMENT | Verifies that all messages have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
-| No | _  | SERVICES_HAVE_COMMENT | Verifies that all services have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
-| No | _  | RPCS_HAVE_COMMENT | Verifies that all rps have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
-| No | _  | FIELDS_HAVE_COMMENT | Verifies that all fields have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
-| No | _  | ENUMS_HAVE_COMMENT | Verifies that all enums have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
-| No | _  | ENUM_FIELDS_HAVE_COMMENT | Verifies that all enum fields have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
-| No | _  | FILE_HAS_COMMENT | Verifies that a file starts with a doc comment. |
-| No | _  | SYNTAX_CONSISTENT | Verifies that syntax is a specified version. The default is proto3. You can configure the version with `.protolint.yaml`. |
+The `-auto_disable` option on the command line can automatically disable all the problems reported by auto-disable rules.
+This feature is helpful when fixing the existing violations breaks the compatibility.
+See AutoDisable columns below.
+
+| Official | Fixable | AutoDisable | ID                                | Purpose                                                                  |
+|----------|---------|---------|-----------------------------------|--------------------------------------------------------------------------|
+| Yes | ✅ | - | ENUM_FIELD_NAMES_PREFIX | Verifies that enum field names are prefixed with its ENUM_NAME_UPPER_SNAKE_CASE.        |
+| Yes | ✅ | ✅ | ENUM_FIELD_NAMES_UPPER_SNAKE_CASE | Verifies that all enum field names are CAPITALS_WITH_UNDERSCORES.        |
+| Yes | ✅ | - | ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH | Verifies that the zero value enum should have the suffix (e.g. "UNSPECIFIED", "INVALID"). The default is "UNSPECIFIED". You can configure the specific suffix with `.protolint.yaml`. |
+| Yes | ✅ | - | ENUM_NAMES_UPPER_CAMEL_CASE       | Verifies that all enum names are CamelCase (with an initial capital).    |
+| Yes | ✅ | - | FILE_NAMES_LOWER_SNAKE_CASE       | Verifies that all file names are lower_snake_case.proto. You can configure the excluded files with `.protolint.yaml`. |
+| Yes | ✅ | - | FIELD_NAMES_LOWER_SNAKE_CASE      | Verifies that all field names are underscore_separated_names.            |
+| Yes | ✅ | - | IMPORTS_SORTED                    | Verifies that all imports are sorted. |
+| Yes | ✅ | - | MESSAGE_NAMES_UPPER_CAMEL_CASE    | Verifies that all message names are CamelCase (with an initial capital). |
+| Yes | ✅ | - | ORDER                             | Verifies that all files should be ordered in the specific manner. |
+| Yes | ✅ | - | PACKAGE_NAME_LOWER_CASE           | Verifies that the package name should not contain any lowercase letters. |
+| Yes | ✅ | - | RPC_NAMES_UPPER_CAMEL_CASE        | Verifies that all rpc names are CamelCase (with an initial capital).     |
+| Yes | ✅ | - | SERVICE_NAMES_UPPER_CAMEL_CASE    | Verifies that all service names are CamelCase (with an initial capital). |
+| Yes | ✅ | - | REPEATED_FIELD_NAMES_PLURALIZED   | Verifies that repeated field names are pluralized names.            |
+| Yes | ✅ | - | QUOTE_CONSISTENT   | Verifies that the use of quote for strings is consistent. The default is double quoted. You can configure the specific quote with `.protolint.yaml`.          |
+| Yes | ✅ | - | INDENT    | Enforces a consistent indentation style. The default style is 2 spaces. Inserting appropriate new lines is also forced by default. You can configure the detail with `.protolint.yaml`. |
+| Yes | ✅ | - | PROTO3_FIELDS_AVOID_REQUIRED      | Verifies that all fields should avoid required for proto3.            |
+| Yes | _  | - | PROTO3_GROUPS_AVOID      | Verifies that all groups should be avoided for proto3.            |
+| Yes | _  | - | MAX_LINE_LENGTH    | Enforces a maximum line length. The length of a line is defined as the number of Unicode characters in the line. The default is 80 characters. You can configure the detail with `.protolint.yaml`. |
+| No | _  | - | SERVICE_NAMES_END_WITH    | Enforces a consistent suffix for service names. You can configure the specific suffix with `.protolint.yaml`. |
+| No | _  | - | FIELD_NAMES_EXCLUDE_PREPOSITIONS | Verifies that all field names don't include prepositions (e.g. "for", "during", "at"). You can configure the specific prepositions and excluded keywords with `.protolint.yaml`. |
+| No | _  | - | MESSAGE_NAMES_EXCLUDE_PREPOSITIONS | Verifies that all message names don't include prepositions (e.g. "With", "For"). You can configure the specific prepositions and excluded keywords with `.protolint.yaml`. |
+| No | _  | - | RPC_NAMES_CASE        | Verifies that all rpc names conform to the specified convention. You need to configure the specific convention with `.protolint.yaml`.     |
+| No | _  | - | MESSAGES_HAVE_COMMENT | Verifies that all messages have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
+| No | _  | - | SERVICES_HAVE_COMMENT | Verifies that all services have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
+| No | _  | - | RPCS_HAVE_COMMENT | Verifies that all rps have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
+| No | _  | - | FIELDS_HAVE_COMMENT | Verifies that all fields have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
+| No | _  | - | ENUMS_HAVE_COMMENT | Verifies that all enums have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
+| No | _  | - | ENUM_FIELDS_HAVE_COMMENT | Verifies that all enum fields have a comment. You can configure to enforce Golang Style comments with `.protolint.yaml`. |
+| No | _  | - | FILE_HAS_COMMENT | Verifies that a file starts with a doc comment. |
+| No | _  | - | SYNTAX_CONSISTENT | Verifies that syntax is a specified version. The default is proto3. You can configure the version with `.protolint.yaml`. |
 
 I recommend that you add `all_default: true` in `.protolint.yaml`, because all linters above are automatically enabled so that you can always enjoy maximum benefits whenever protolint is updated.
 
@@ -383,6 +391,10 @@ enum Foo {
   THIRD_VALUE = 2;   // spits out an error
 }
 ```
+
+Setting the command-line option `-auto_disable` to `next` or `this` inserts disable commands whenever spotting problems. 
+
+You can specify `-fix` option together. The rules supporting auto_disable suppress the violations instead of fixing them that cause a schema incompatibility.
 
 __Config file__
 

--- a/_testdata/autodisable/disabled_enum_field_names.proto
+++ b/_testdata/autodisable/disabled_enum_field_names.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+enum Enum {
+  // protolint:disable:next ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+  ENUM_unknown_UNSPECIFIED = 0;
+}

--- a/_testdata/autodisable/disabled_inline_enum_field_names.proto
+++ b/_testdata/autodisable/disabled_inline_enum_field_names.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+enum Enum {
+  ENUM_unknown_UNSPECIFIED = 0; // protolint:disable:this ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+}

--- a/_testdata/autodisable/disabled_inline_line_enum_field_names.proto
+++ b/_testdata/autodisable/disabled_inline_line_enum_field_names.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+enum Enum {
+  // protolint:disable:next ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
+  ENUM_unknown = 0; // protolint:disable:this ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+  // protolint:disable:next ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+  ENUM_ALIAS_started_lap = 1; // See the reference page.
+}

--- a/_testdata/autodisable/disabled_many_enum_field_names.proto
+++ b/_testdata/autodisable/disabled_many_enum_field_names.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+enum Enum {
+  option allow_alias = true;
+  // protolint:disable:next ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+  ENUM_unknown_UNSPECIFIED = 0;
+}
+
+enum EnumAlias {
+  // protolint:disable:next ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+  ENUM_ALIAS_started_lap = 1;
+  // protolint:disable:next ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+  ENUM_ALIAS_RUNNINGlapUntil = 2 [(custom_option) = "hello world"];
+}

--- a/_testdata/autodisable/disabled_merge_inline_enum_field_names.proto
+++ b/_testdata/autodisable/disabled_merge_inline_enum_field_names.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+enum Enum {
+  // protolint:disable:next ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
+  ENUM_unknown = 0; // protolint:disable:this ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+  ALIAS_started_lap = 1; // protolint:disable:this ENUM_FIELD_NAMES_PREFIX ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+}

--- a/_testdata/autodisable/disabled_nomerge_enum_field_names.proto
+++ b/_testdata/autodisable/disabled_nomerge_enum_field_names.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+enum Enum {
+  // protolint:disable:next ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
+  // protolint:disable:next ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+  ENUM_unknown = 0;
+  // protolint:disable:next ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+  ENUM_ALIAS_started_lap = 1;
+}

--- a/_testdata/autodisable/invalid_enum_field_names.proto
+++ b/_testdata/autodisable/invalid_enum_field_names.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+enum Enum {
+  ENUM_unknown_UNSPECIFIED = 0;
+}

--- a/_testdata/autodisable/invalid_enum_field_names_comment.proto
+++ b/_testdata/autodisable/invalid_enum_field_names_comment.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+enum Enum {
+  // protolint:disable:next ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
+  ENUM_unknown = 0;
+  ENUM_ALIAS_started_lap = 1;
+}

--- a/_testdata/autodisable/invalid_inline_disable_enum_field_names.proto
+++ b/_testdata/autodisable/invalid_inline_disable_enum_field_names.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+enum Enum {
+  // protolint:disable:next ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
+  ENUM_unknown = 0;
+  ALIAS_started_lap = 1; // protolint:disable:this ENUM_FIELD_NAMES_PREFIX
+}

--- a/_testdata/autodisable/invalid_inline_enum_field_names.proto
+++ b/_testdata/autodisable/invalid_inline_enum_field_names.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+enum Enum {
+  // protolint:disable:next ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
+  ENUM_unknown = 0;
+  ENUM_ALIAS_started_lap = 1; // See the reference page.
+}

--- a/_testdata/autodisable/invalid_many_enum_field_names.proto
+++ b/_testdata/autodisable/invalid_many_enum_field_names.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+enum Enum {
+  option allow_alias = true;
+  ENUM_unknown_UNSPECIFIED = 0;
+}
+
+enum EnumAlias {
+  ENUM_ALIAS_started_lap = 1;
+  ENUM_ALIAS_RUNNINGlapUntil = 2 [(custom_option) = "hello world"];
+}

--- a/_testdata/rules/enumFieldNamesUpperSnakeCase/disable_next.proto
+++ b/_testdata/rules/enumFieldNamesUpperSnakeCase/disable_next.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+enum enum {
+    option allow_alias = true;
+    // protolint:disable:next ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+    unknown = 0;
+}
+
+enum enumAlias {
+    // protolint:disable:next ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+    started_lap = 1;
+    // protolint:disable:next ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+    RUNNINGlapUntil = 2 [(custom_option) = "hello world"];
+}

--- a/_testdata/rules/enumFieldNamesUpperSnakeCase/disable_this.proto
+++ b/_testdata/rules/enumFieldNamesUpperSnakeCase/disable_this.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+enum enum {
+    option allow_alias = true;
+    unknown = 0; // protolint:disable:this ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+}
+
+enum enumAlias {
+    started_lap = 1; // protolint:disable:this ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+    RUNNINGlapUntil = 2 [(custom_option) = "hello world"]; // protolint:disable:this ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+}

--- a/_testdata/visitor/disable_next.proto
+++ b/_testdata/visitor/disable_next.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+enum Enum {
+  // protolint:disable:next ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+  ENUM_unknown_UNSPECIFIED = 0;
+}

--- a/_testdata/visitor/disable_this.proto
+++ b/_testdata/visitor/disable_this.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+enum Enum {
+  ENUM_unknown_UNSPECIFIED = 0; // protolint:disable:this ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+}

--- a/_testdata/visitor/invalid.proto
+++ b/_testdata/visitor/invalid.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+enum Enum {
+  ENUM_unknown_UNSPECIFIED = 0;
+}

--- a/internal/addon/rules/enumFieldNamesUpperSnakeCaseRule.go
+++ b/internal/addon/rules/enumFieldNamesUpperSnakeCaseRule.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"github.com/yoheimuta/go-protoparser/v4/lexer"
 	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/protolint/linter/autodisable"
 	"github.com/yoheimuta/protolint/linter/fixer"
 	"github.com/yoheimuta/protolint/linter/report"
 	"github.com/yoheimuta/protolint/linter/strs"
@@ -12,15 +13,21 @@ import (
 // EnumFieldNamesUpperSnakeCaseRule verifies that all enum field names are CAPITALS_WITH_UNDERSCORES.
 // See https://developers.google.com/protocol-buffers/docs/style#enums.
 type EnumFieldNamesUpperSnakeCaseRule struct {
-	fixMode bool
+	fixMode         bool
+	autoDisableType autodisable.PlacementType
 }
 
 // NewEnumFieldNamesUpperSnakeCaseRule creates a new EnumFieldNamesUpperSnakeCaseRule.
 func NewEnumFieldNamesUpperSnakeCaseRule(
 	fixMode bool,
+	autoDisableType autodisable.PlacementType,
 ) EnumFieldNamesUpperSnakeCaseRule {
+	if autoDisableType != autodisable.Noop {
+		fixMode = false
+	}
 	return EnumFieldNamesUpperSnakeCaseRule{
-		fixMode: fixMode,
+		fixMode:         fixMode,
+		autoDisableType: autoDisableType,
 	}
 }
 
@@ -49,7 +56,7 @@ func (r EnumFieldNamesUpperSnakeCaseRule) Apply(proto *parser.Proto) ([]report.F
 	v := &enumFieldNamesUpperSnakeCaseVisitor{
 		BaseFixableVisitor: base,
 	}
-	return visitor.RunVisitor(v, proto, r.ID())
+	return visitor.RunVisitorAutoDisable(v, proto, r.ID(), r.autoDisableType)
 }
 
 type enumFieldNamesUpperSnakeCaseVisitor struct {

--- a/internal/addon/rules/fileNamesLowerSnakeCaseRule_test.go
+++ b/internal/addon/rules/fileNamesLowerSnakeCaseRule_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/yoheimuta/protolint/internal/linter/file"
 	"github.com/yoheimuta/protolint/internal/setting_test"
+	"github.com/yoheimuta/protolint/internal/util_test"
 	"github.com/yoheimuta/protolint/linter/strs"
 
 	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
@@ -142,12 +143,12 @@ func TestFileNamesLowerSnakeCaseRule_Apply_fix(t *testing.T) {
 			r := rules.NewFileNamesLowerSnakeCaseRule(test.inputExcluded, true)
 
 			dataDir := strs.ToLowerCamelCase(r.ID())
-			input, err := newTestData(setting_test.TestDataPath("rules", dataDir, test.inputFilename))
+			input, err := util_test.NewTestData(setting_test.TestDataPath("rules", dataDir, test.inputFilename))
 			if err != nil {
 				t.Errorf("got err %v", err)
 				return
 			}
-			proto, err := file.NewProtoFile(input.filePath, input.filePath).Parse(false)
+			proto, err := file.NewProtoFile(input.FilePath, input.FilePath).Parse(false)
 			if err != nil {
 				t.Errorf(err.Error())
 				return
@@ -158,8 +159,8 @@ func TestFileNamesLowerSnakeCaseRule_Apply_fix(t *testing.T) {
 				return
 			}
 			if test.wantAbort {
-				if _, err := os.Stat(input.filePath); os.IsNotExist(err) {
-					t.Errorf("not found %q, but want to locate it", input.filePath)
+				if _, err := os.Stat(input.FilePath); os.IsNotExist(err) {
+					t.Errorf("not found %q, but want to locate it", input.FilePath)
 					return
 				}
 				for _, f := range fs {
@@ -177,7 +178,7 @@ func TestFileNamesLowerSnakeCaseRule_Apply_fix(t *testing.T) {
 				return
 			}
 
-			err = os.Rename(wantPath, input.filePath)
+			err = os.Rename(wantPath, input.FilePath)
 			if err != nil {
 				t.Errorf("got err %v", err)
 			}

--- a/internal/addon/rules/importsSortedRule_test.go
+++ b/internal/addon/rules/importsSortedRule_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 
 	"github.com/yoheimuta/protolint/internal/setting_test"
+	"github.com/yoheimuta/protolint/internal/util_test"
 
 	"github.com/yoheimuta/protolint/internal/linter/file"
 
@@ -142,8 +143,8 @@ func TestImportsSortedRule_Apply(t *testing.T) {
 
 func newTestImportsSortedData(
 	fileName string,
-) (testData, error) {
-	return newTestData(testImportSortedProtoPath(fileName))
+) (util_test.TestData, error) {
+	return util_test.NewTestData(testImportSortedProtoPath(fileName))
 }
 
 func TestImportsSortedRule_Apply_fix(t *testing.T) {
@@ -193,7 +194,7 @@ func TestImportsSortedRule_Apply_fix(t *testing.T) {
 				return
 			}
 
-			proto, err := file.NewProtoFile(input.filePath, input.filePath).Parse(false)
+			proto, err := file.NewProtoFile(input.FilePath, input.FilePath).Parse(false)
 			if err != nil {
 				t.Errorf(err.Error())
 				return
@@ -205,16 +206,16 @@ func TestImportsSortedRule_Apply_fix(t *testing.T) {
 				return
 			}
 
-			got, err := input.data()
-			if !reflect.DeepEqual(got, want.originData) {
+			got, err := input.Data()
+			if !reflect.DeepEqual(got, want.OriginData) {
 				t.Errorf(
 					"got %s(%v), but want %s(%v)",
 					string(got), got,
-					string(want.originData), want.originData,
+					string(want.OriginData), want.OriginData,
 				)
 			}
 
-			err = input.restore()
+			err = input.Restore()
 			if err != nil {
 				t.Errorf("got err %v", err)
 			}

--- a/internal/addon/rules/indentRule_test.go
+++ b/internal/addon/rules/indentRule_test.go
@@ -1,12 +1,11 @@
 package rules_test
 
 import (
-	"io/ioutil"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/yoheimuta/protolint/internal/osutil"
+	"github.com/yoheimuta/protolint/internal/util_test"
 
 	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 
@@ -271,38 +270,10 @@ Fix https://github.com/yoheimuta/protolint/issues/139`,
 	}
 }
 
-type testData struct {
-	filePath   string
-	originData []byte
-}
-
 func newTestIndentData(
 	fileName string,
-) (testData, error) {
-	return newTestData(setting_test.TestDataPath("rules", "indentrule", fileName))
-}
-
-func newTestData(
-	filePath string,
-) (testData, error) {
-	data, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		return testData{}, nil
-	}
-	return testData{
-		filePath:   filePath,
-		originData: data,
-	}, nil
-}
-
-func (d testData) data() ([]byte, error) {
-	return ioutil.ReadFile(d.filePath)
-}
-
-func (d testData) restore() error {
-	newlineChar := "\n"
-	lines := strings.Split(string(d.originData), newlineChar)
-	return osutil.WriteLinesToExistingFile(d.filePath, lines, newlineChar)
+) (util_test.TestData, error) {
+	return util_test.NewTestData(setting_test.TestDataPath("rules", "indentrule", fileName))
 }
 
 func TestIndentRule_Apply_fix(t *testing.T) {
@@ -376,9 +347,9 @@ func TestIndentRule_Apply_fix(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		inputTestData      testData
+		inputTestData      util_test.TestData
 		inputInsertNewline bool
-		wantCorrectData    testData
+		wantCorrectData    util_test.TestData
 	}{
 		{
 			name:            "correct syntax",
@@ -442,7 +413,7 @@ func TestIndentRule_Apply_fix(t *testing.T) {
 				true,
 			)
 
-			proto, err := file.NewProtoFile(test.inputTestData.filePath, test.inputTestData.filePath).Parse(false)
+			proto, err := file.NewProtoFile(test.inputTestData.FilePath, test.inputTestData.FilePath).Parse(false)
 			if err != nil {
 				t.Errorf(err.Error())
 				return
@@ -454,18 +425,18 @@ func TestIndentRule_Apply_fix(t *testing.T) {
 				return
 			}
 
-			got, err := test.inputTestData.data()
-			if !reflect.DeepEqual(got, test.wantCorrectData.originData) {
+			got, err := test.inputTestData.Data()
+			if !reflect.DeepEqual(got, test.wantCorrectData.OriginData) {
 				t.Errorf(
 					"got %s(%v), but want %s(%v)",
 					string(got), got,
-					string(test.wantCorrectData.originData), test.wantCorrectData.originData,
+					string(test.wantCorrectData.OriginData), test.wantCorrectData.OriginData,
 				)
 			}
 
 			// restore the file
 			defer func() {
-				err = test.inputTestData.restore()
+				err = test.inputTestData.Restore()
 				if err != nil {
 					t.Errorf("got err %v", err)
 				}
@@ -477,7 +448,7 @@ func TestIndentRule_Apply_fix(t *testing.T) {
 				!test.inputInsertNewline,
 				false,
 			)
-			proto, err = file.NewProtoFile(test.inputTestData.filePath, test.inputTestData.filePath).Parse(false)
+			proto, err = file.NewProtoFile(test.inputTestData.FilePath, test.inputTestData.FilePath).Parse(false)
 			if err != nil {
 				t.Errorf(err.Error())
 				return

--- a/internal/addon/rules/util_test.go
+++ b/internal/addon/rules/util_test.go
@@ -3,6 +3,7 @@ package rules_test
 import (
 	"github.com/yoheimuta/protolint/internal/linter/file"
 	"github.com/yoheimuta/protolint/internal/setting_test"
+	"github.com/yoheimuta/protolint/internal/util_test"
 	"github.com/yoheimuta/protolint/linter/rule"
 	"github.com/yoheimuta/protolint/linter/strs"
 
@@ -18,19 +19,19 @@ func testApplyFix(
 ) {
 	dataDir := strs.ToLowerCamelCase(r.ID())
 
-	input, err := newTestData(setting_test.TestDataPath("rules", dataDir, inputFilename))
+	input, err := util_test.NewTestData(setting_test.TestDataPath("rules", dataDir, inputFilename))
 	if err != nil {
 		t.Errorf("got err %v", err)
 		return
 	}
 
-	want, err := newTestData(setting_test.TestDataPath("rules", dataDir, wantFilename))
+	want, err := util_test.NewTestData(setting_test.TestDataPath("rules", dataDir, wantFilename))
 	if err != nil {
 		t.Errorf("got err %v", err)
 		return
 	}
 
-	proto, err := file.NewProtoFile(input.filePath, input.filePath).Parse(false)
+	proto, err := file.NewProtoFile(input.FilePath, input.FilePath).Parse(false)
 	if err != nil {
 		t.Errorf(err.Error())
 		return
@@ -42,16 +43,16 @@ func testApplyFix(
 		return
 	}
 
-	got, err := input.data()
-	if !reflect.DeepEqual(got, want.originData) {
+	got, err := input.Data()
+	if !reflect.DeepEqual(got, want.OriginData) {
 		t.Errorf(
 			"got %s(%v), but want %s(%v)",
 			string(got), got,
-			string(want.originData), want.originData,
+			string(want.OriginData), want.OriginData,
 		)
 	}
 
-	err = input.restore()
+	err = input.Restore()
 	if err != nil {
 		t.Errorf("got err %v", err)
 	}

--- a/internal/cmd/subcmds/lint/autoDisableFlag.go
+++ b/internal/cmd/subcmds/lint/autoDisableFlag.go
@@ -1,0 +1,42 @@
+package lint
+
+import (
+	"fmt"
+
+	"github.com/yoheimuta/protolint/linter/autodisable"
+)
+
+type autoDisableFlag struct {
+	raw             string
+	autoDisableType autodisable.PlacementType
+}
+
+func (f *autoDisableFlag) String() string {
+	return fmt.Sprint(f.raw)
+}
+
+func (f *autoDisableFlag) Set(value string) error {
+	if f.autoDisableType != 0 {
+		return fmt.Errorf("auto_disable is already set")
+	}
+
+	r, err := GetAutoDisableType(value)
+	if err != nil {
+		return err
+	}
+	f.raw = value
+	f.autoDisableType = r
+	return nil
+}
+
+// GetAutoDisableType returns a type from the specified key.
+func GetAutoDisableType(value string) (autodisable.PlacementType, error) {
+	rs := map[string]autodisable.PlacementType{
+		"next": autodisable.Next,
+		"this": autodisable.ThisThenNext,
+	}
+	if r, ok := rs[value]; ok {
+		return r, nil
+	}
+	return autodisable.Noop, fmt.Errorf(`available auto_disable are "next" and "this"`)
+}

--- a/internal/cmd/subcmds/lint/cmdLintConfig.go
+++ b/internal/cmd/subcmds/lint/cmdLintConfig.go
@@ -6,16 +6,18 @@ import (
 	"github.com/yoheimuta/protolint/internal/linter/config"
 	"github.com/yoheimuta/protolint/internal/linter/file"
 	"github.com/yoheimuta/protolint/internal/linter/report"
+	"github.com/yoheimuta/protolint/linter/autodisable"
 	"github.com/yoheimuta/protolint/linter/rule"
 )
 
 // CmdLintConfig is a config for lint command.
 type CmdLintConfig struct {
-	external config.ExternalConfig
-	fixMode  bool
-	verbose  bool
-	reporter report.Reporter
-	plugins  []shared.RuleSet
+	external        config.ExternalConfig
+	fixMode         bool
+	autoDisableType autodisable.PlacementType
+	verbose         bool
+	reporter        report.Reporter
+	plugins         []shared.RuleSet
 }
 
 // NewCmdLintConfig creates a new CmdLintConfig.
@@ -24,11 +26,12 @@ func NewCmdLintConfig(
 	flags Flags,
 ) CmdLintConfig {
 	return CmdLintConfig{
-		external: externalConfig,
-		fixMode:  flags.FixMode,
-		verbose:  flags.Verbose,
-		reporter: flags.Reporter,
-		plugins:  flags.Plugins,
+		external:        externalConfig,
+		fixMode:         flags.FixMode,
+		autoDisableType: flags.AutoDisableType,
+		verbose:         flags.Verbose,
+		reporter:        flags.Reporter,
+		plugins:         flags.Plugins,
 	}
 }
 
@@ -36,7 +39,7 @@ func NewCmdLintConfig(
 func (c CmdLintConfig) GenRules(
 	f file.ProtoFile,
 ) ([]rule.HasApply, error) {
-	allRules, err := subcmds.NewAllRules(c.external.Lint.RulesOption, c.fixMode, c.verbose, c.plugins)
+	allRules, err := subcmds.NewAllRules(c.external.Lint.RulesOption, c.fixMode, c.autoDisableType, c.verbose, c.plugins)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/subcmds/list/cmdList.go
+++ b/internal/cmd/subcmds/list/cmdList.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/yoheimuta/protolint/internal/cmd/subcmds"
 	"github.com/yoheimuta/protolint/internal/osutil"
+	"github.com/yoheimuta/protolint/linter/autodisable"
 	"github.com/yoheimuta/protolint/linter/rule"
 )
 
@@ -68,7 +69,7 @@ type hasIDAndPurpose interface {
 }
 
 func hasIDAndPurposes(plugins []shared.RuleSet) ([]hasIDAndPurpose, error) {
-	rs, err := subcmds.NewAllRules(config.RulesOption{}, false, false, plugins)
+	rs, err := subcmds.NewAllRules(config.RulesOption{}, false, autodisable.Noop, false, plugins)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/subcmds/rules.go
+++ b/internal/cmd/subcmds/rules.go
@@ -6,16 +6,18 @@ import (
 	"github.com/yoheimuta/protolint/internal/addon/rules"
 	"github.com/yoheimuta/protolint/internal/linter/config"
 	internalrule "github.com/yoheimuta/protolint/internal/linter/rule"
+	"github.com/yoheimuta/protolint/linter/autodisable"
 )
 
 // NewAllRules creates new all rules.
 func NewAllRules(
 	option config.RulesOption,
 	fixMode bool,
+	autoDisableType autodisable.PlacementType,
 	verbose bool,
 	plugins []shared.RuleSet,
 ) (internalrule.Rules, error) {
-	rs := newAllInternalRules(option, fixMode)
+	rs := newAllInternalRules(option, fixMode, autoDisableType)
 
 	es, err := plugin.GetExternalRules(plugins, fixMode, verbose)
 	if err != nil {
@@ -28,6 +30,7 @@ func NewAllRules(
 func newAllInternalRules(
 	option config.RulesOption,
 	fixMode bool,
+	autoDisableType autodisable.PlacementType,
 ) internalrule.Rules {
 	syntaxConsistent := option.SyntaxConsistent
 	fileNamesLowerSnakeCase := option.FileNamesLowerSnakeCase

--- a/internal/cmd/subcmds/rules.go
+++ b/internal/cmd/subcmds/rules.go
@@ -76,7 +76,7 @@ func newAllInternalRules(
 		),
 
 		rules.NewEnumFieldNamesPrefixRule(fixMode),
-		rules.NewEnumFieldNamesUpperSnakeCaseRule(fixMode),
+		rules.NewEnumFieldNamesUpperSnakeCaseRule(fixMode, autoDisableType),
 		rules.NewEnumFieldNamesZeroValueEndWithRule(
 			enumFieldNamesZeroValueEndWith.Suffix,
 			fixMode,

--- a/internal/linter/config/externalConfig_test.go
+++ b/internal/linter/config/externalConfig_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/yoheimuta/protolint/internal/filepathutil"
+	"github.com/yoheimuta/protolint/linter/autodisable"
 
 	"github.com/yoheimuta/protolint/internal/cmd/subcmds"
 	"github.com/yoheimuta/protolint/internal/linter/config"
@@ -97,7 +98,7 @@ func TestExternalConfig_ShouldSkipRule(t *testing.T) {
 		},
 	}
 
-	allRules, err := subcmds.NewAllRules(config.RulesOption{}, false, false, nil)
+	allRules, err := subcmds.NewAllRules(config.RulesOption{}, false, autodisable.Noop, false, nil)
 	if err != nil {
 		t.Error(err)
 		return

--- a/internal/util_test/testFile.go
+++ b/internal/util_test/testFile.go
@@ -1,0 +1,40 @@
+package util_test
+
+import (
+	"io/ioutil"
+	"strings"
+
+	"github.com/yoheimuta/protolint/internal/osutil"
+)
+
+// TestData is a wrapped test file.
+type TestData struct {
+	FilePath   string
+	OriginData []byte
+}
+
+// NewTestData create a new TestData.
+func NewTestData(
+	filePath string,
+) (TestData, error) {
+	data, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return TestData{}, nil
+	}
+	return TestData{
+		FilePath:   filePath,
+		OriginData: data,
+	}, nil
+}
+
+// Data returns a content.
+func (d TestData) Data() ([]byte, error) {
+	return ioutil.ReadFile(d.FilePath)
+}
+
+// Restore writes the original content back to the file.
+func (d TestData) Restore() error {
+	newlineChar := "\n"
+	lines := strings.Split(string(d.OriginData), newlineChar)
+	return osutil.WriteLinesToExistingFile(d.FilePath, lines, newlineChar)
+}

--- a/linter/autodisable/commentator.go
+++ b/linter/autodisable/commentator.go
@@ -1,0 +1,94 @@
+package autodisable
+
+import (
+	"log"
+
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/protolint/linter/disablerule"
+	"github.com/yoheimuta/protolint/linter/fixer"
+)
+
+type commentator struct {
+	fixing *fixer.BaseFixing
+	ruleID string
+}
+
+func newCommentator(filename, ruleID string) (*commentator, error) {
+	f, err := fixer.NewBaseFixing(filename)
+	if err != nil {
+		return nil, err
+	}
+	return &commentator{
+		fixing: f,
+		ruleID: ruleID,
+	}, nil
+}
+
+func (c *commentator) insertNewline(offset int) {
+	comment := disablerule.PrefixDisableNext + " " + c.ruleID
+
+	space := ""
+	pos := offset
+loop:
+	for i := offset; 0 < i; i-- {
+		ch := c.fixing.Content()[i]
+		switch ch {
+		case ' ', '\t':
+			space += " "
+		case '\n', '\r':
+			break loop
+		default:
+			pos = i
+			space = ""
+		}
+	}
+	c.insert("// "+comment+c.fixing.LineEnding()+space, pos)
+}
+
+func (c *commentator) tryMergeInline(inline *parser.Comment) bool {
+	matches := disablerule.ReDisableThis.FindStringIndex(inline.Raw)
+	log.Println(matches)
+	if matches != nil {
+		extracted := inline.Raw[matches[0]:matches[1]]
+		log.Println(extracted)
+		startPos := inline.Meta.Pos.Offset
+		c.fixing.Replace(fixer.TextEdit{
+			Pos:     startPos + matches[0],
+			End:     startPos + matches[1] - 1,
+			NewText: []byte(extracted + " " + c.ruleID),
+		})
+		return true
+	}
+	return false
+}
+
+func (c *commentator) insertInline(offset int) {
+	comment := disablerule.PrefixDisableThis + " " + c.ruleID
+
+	pos := offset
+	content := c.fixing.Content()
+loop:
+	for i := offset; i < len(content); i++ {
+		ch := content[i]
+		switch ch {
+		case ' ', '\t':
+		case '\n', '\r':
+			break loop
+		default:
+			pos = i
+		}
+	}
+	c.insert(" // "+comment, pos+1)
+}
+
+func (c *commentator) finalize() error {
+	return c.fixing.Finally()
+}
+
+func (c *commentator) insert(text string, pos int) {
+	c.fixing.Replace(fixer.TextEdit{
+		Pos:     pos,
+		End:     pos - 1,
+		NewText: []byte(text),
+	})
+}

--- a/linter/autodisable/nextPlacementStrategy.go
+++ b/linter/autodisable/nextPlacementStrategy.go
@@ -1,0 +1,24 @@
+package autodisable
+
+import "github.com/yoheimuta/go-protoparser/v4/parser"
+
+type nextPlacementStrategy struct {
+	c *commentator
+}
+
+func newNextPlacementStrategy(c *commentator) *nextPlacementStrategy {
+	return &nextPlacementStrategy{
+		c: c,
+	}
+}
+
+func (p *nextPlacementStrategy) Disable(
+	offset int,
+	_ []*parser.Comment,
+	_ *parser.Comment) {
+	p.c.insertNewline(offset)
+}
+
+func (p *nextPlacementStrategy) Finalize() error {
+	return p.c.finalize()
+}

--- a/linter/autodisable/placementStrategy.go
+++ b/linter/autodisable/placementStrategy.go
@@ -1,0 +1,53 @@
+package autodisable
+
+import "github.com/yoheimuta/go-protoparser/v4/parser"
+
+// PlacementType is a selection of the placement strategies.
+type PlacementType int
+
+const (
+	// Noop does nothing
+	Noop PlacementType = iota
+	// ThisThenNext puts inline comments.
+	ThisThenNext
+	// Next puts newline comments.
+	Next
+)
+
+// NewPlacementStrategy creates a strategy object.
+func NewPlacementStrategy(ptype PlacementType, filename, ruleID string) (PlacementStrategy, error) {
+	if ptype == Noop {
+		return &noopPlacementStrategy{}, nil
+	}
+
+	c, err := newCommentator(filename, ruleID)
+	if err != nil {
+		return nil, err
+	}
+	switch ptype {
+	case ThisThenNext:
+		return newThisThenNextPlacementStrategy(c), err
+	case Next:
+		return newNextPlacementStrategy(c), err
+	default:
+		return nil, nil
+	}
+}
+
+// PlacementStrategy is an abstraction to put a comment.
+type PlacementStrategy interface {
+	Disable(offset int, comments []*parser.Comment, inline *parser.Comment)
+	Finalize() error
+}
+
+type noopPlacementStrategy struct{}
+
+func (p *noopPlacementStrategy) Disable(
+	offset int,
+	comments []*parser.Comment,
+	_ *parser.Comment) {
+}
+
+func (p *noopPlacementStrategy) Finalize() error {
+	return nil
+}

--- a/linter/autodisable/placementStrategy_test.go
+++ b/linter/autodisable/placementStrategy_test.go
@@ -1,0 +1,198 @@
+package autodisable_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
+	"github.com/yoheimuta/protolint/internal/setting_test"
+	"github.com/yoheimuta/protolint/internal/util_test"
+	"github.com/yoheimuta/protolint/linter/autodisable"
+)
+
+type inputDisable struct {
+	inputOffset   int
+	inputComments []*parser.Comment
+	inputInline   *parser.Comment
+}
+
+func TestPlacementStrategy_Disable(t *testing.T) {
+	tests := []struct {
+		name               string
+		inputPlacementType autodisable.PlacementType
+		inputFilename      string
+		inputRoleID        string
+		inputDisable       []inputDisable
+		wantFilename       string
+	}{
+		{
+			name:               "no auto disable",
+			inputPlacementType: autodisable.Noop,
+			inputRoleID:        "ENUM_FIELD_NAMES_UPPER_SNAKE_CASE",
+			inputDisable: []inputDisable{
+				{
+					inputOffset: 34,
+				},
+			},
+			inputFilename: "invalid_enum_field_names.proto",
+			wantFilename:  "invalid_enum_field_names.proto",
+		},
+		{
+			name:               "add a new line comment",
+			inputPlacementType: autodisable.Next,
+			inputRoleID:        "ENUM_FIELD_NAMES_UPPER_SNAKE_CASE",
+			inputDisable: []inputDisable{
+				{
+					inputOffset: 34,
+				},
+			},
+			inputFilename: "invalid_enum_field_names.proto",
+			wantFilename:  "disabled_enum_field_names.proto",
+		},
+		{
+			name:               "add new three line comments",
+			inputPlacementType: autodisable.Next,
+			inputRoleID:        "ENUM_FIELD_NAMES_UPPER_SNAKE_CASE",
+			inputDisable: []inputDisable{
+				{
+					inputOffset: 63,
+				},
+				{
+					inputOffset: 115,
+				},
+				{
+					inputOffset: 145,
+				},
+			},
+			inputFilename: "invalid_many_enum_field_names.proto",
+			wantFilename:  "disabled_many_enum_field_names.proto",
+		},
+		{
+			name:               "not merge the comment",
+			inputPlacementType: autodisable.Next,
+			inputRoleID:        "ENUM_FIELD_NAMES_UPPER_SNAKE_CASE",
+			inputDisable: []inputDisable{
+				{
+					inputOffset: 99,
+				},
+				{
+					inputOffset: 119,
+				},
+			},
+			inputFilename: "invalid_enum_field_names_comment.proto",
+			wantFilename:  "disabled_nomerge_enum_field_names.proto",
+		},
+		{
+			name:               "add an inline comment",
+			inputPlacementType: autodisable.ThisThenNext,
+			inputRoleID:        "ENUM_FIELD_NAMES_UPPER_SNAKE_CASE",
+			inputDisable: []inputDisable{
+				{
+					inputOffset: 34,
+				},
+			},
+			inputFilename: "invalid_enum_field_names.proto",
+			wantFilename:  "disabled_inline_enum_field_names.proto",
+		},
+		{
+			name:               "merge an inline comment",
+			inputPlacementType: autodisable.ThisThenNext,
+			inputRoleID:        "ENUM_FIELD_NAMES_UPPER_SNAKE_CASE",
+			inputDisable: []inputDisable{
+				{
+					inputOffset: 99,
+				},
+				{
+					inputOffset: 119,
+					inputInline: &parser.Comment{
+						Raw:  `// protolint:disable:this ENUM_FIELD_NAMES_PREFIX`,
+						Meta: meta.Meta{Pos: meta.Position{Offset: 142}},
+					},
+				},
+			},
+			inputFilename: "invalid_inline_disable_enum_field_names.proto",
+			wantFilename:  "disabled_merge_inline_enum_field_names.proto",
+		},
+		{
+			name:               "add an inline comment and a line comment",
+			inputPlacementType: autodisable.ThisThenNext,
+			inputRoleID:        "ENUM_FIELD_NAMES_UPPER_SNAKE_CASE",
+			inputDisable: []inputDisable{
+				{
+					inputOffset: 99,
+				},
+				{
+					inputOffset: 119,
+					inputInline: &parser.Comment{
+						Raw: `// See the reference page.`,
+					},
+				},
+			},
+			inputFilename: "invalid_inline_enum_field_names.proto",
+			wantFilename:  "disabled_inline_line_enum_field_names.proto",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			inputFilePath := setting_test.TestDataPath("autodisable", test.inputFilename)
+			wantFilePath := setting_test.TestDataPath("autodisable", test.wantFilename)
+
+			strategy, err := autodisable.NewPlacementStrategy(
+				test.inputPlacementType,
+				inputFilePath,
+				test.inputRoleID,
+			)
+			if err != nil {
+				t.Errorf("got err %v, but want nil", err)
+				return
+			}
+			testDisable(t, strategy, test.inputDisable, inputFilePath, wantFilePath)
+		})
+	}
+}
+
+func testDisable(
+	t *testing.T,
+	strategy autodisable.PlacementStrategy,
+	inputDisable []inputDisable,
+	inputFilePath string,
+	wantFilePath string,
+) {
+	input, err := util_test.NewTestData(inputFilePath)
+	if err != nil {
+		t.Errorf("got err %v", err)
+		return
+	}
+
+	want, err := util_test.NewTestData(wantFilePath)
+	if err != nil {
+		t.Errorf("got err %v", err)
+		return
+	}
+
+	for _, p := range inputDisable {
+		strategy.Disable(p.inputOffset, p.inputComments, p.inputInline)
+	}
+	err = strategy.Finalize()
+	if err != nil {
+		t.Errorf("got err %v", err)
+		return
+	}
+
+	got, _ := input.Data()
+	if !reflect.DeepEqual(got, want.OriginData) {
+		t.Errorf(
+			"got %s(%v), but want %s(%v)",
+			string(got), got,
+			string(want.OriginData), want.OriginData,
+		)
+	}
+
+	err = input.Restore()
+	if err != nil {
+		t.Errorf("got err %v", err)
+	}
+}

--- a/linter/autodisable/thisThenNextPlacementStrategy.go
+++ b/linter/autodisable/thisThenNextPlacementStrategy.go
@@ -1,0 +1,32 @@
+package autodisable
+
+import "github.com/yoheimuta/go-protoparser/v4/parser"
+
+type thisThenNextPlacementStrategy struct {
+	c *commentator
+}
+
+func newThisThenNextPlacementStrategy(c *commentator) *thisThenNextPlacementStrategy {
+	return &thisThenNextPlacementStrategy{
+		c: c,
+	}
+}
+
+func (p *thisThenNextPlacementStrategy) Disable(
+	offset int,
+	comments []*parser.Comment,
+	inline *parser.Comment) {
+	if inline == nil {
+		p.c.insertInline(offset)
+		return
+	}
+	if p.c.tryMergeInline(inline) {
+		return
+	}
+
+	p.c.insertNewline(offset)
+}
+
+func (p *thisThenNextPlacementStrategy) Finalize() error {
+	return p.c.finalize()
+}

--- a/linter/disablerule/command.go
+++ b/linter/disablerule/command.go
@@ -15,11 +15,20 @@ const (
 	commandDisableThis
 )
 
+// comment prefix
+const (
+	PrefixDisable     = `protolint:disable`
+	PrefixEnable      = `protolint:enable`
+	PrefixDisableNext = `protolint:disable:next`
+	PrefixDisableThis = `protolint:disable:this`
+)
+
+// comment prefix regexp
 var (
-	reDisable     = regexp.MustCompile(`protolint:disable (.*)`)
-	reEnable      = regexp.MustCompile(`protolint:enable (.*)`)
-	reDisableNext = regexp.MustCompile(`protolint:disable:next (.*)`)
-	reDisableThis = regexp.MustCompile(`protolint:disable:this (.*)`)
+	ReDisable     = regexp.MustCompile(PrefixDisable + ` (.*)`)
+	ReEnable      = regexp.MustCompile(PrefixEnable + ` (.*)`)
+	ReDisableNext = regexp.MustCompile(PrefixDisableNext + ` (.*)`)
+	ReDisableThis = regexp.MustCompile(PrefixDisableThis + ` (.*)`)
 )
 
 type command struct {
@@ -30,7 +39,7 @@ type command struct {
 func newCommand(
 	comment string,
 ) (command, error) {
-	subs := reDisable.FindStringSubmatch(comment)
+	subs := ReDisable.FindStringSubmatch(comment)
 	if len(subs) == 2 {
 		ruleIDs := strings.Fields(strings.TrimSpace(subs[1]))
 		return command{
@@ -39,7 +48,7 @@ func newCommand(
 		}, nil
 	}
 
-	subs = reEnable.FindStringSubmatch(comment)
+	subs = ReEnable.FindStringSubmatch(comment)
 	if len(subs) == 2 {
 		ruleIDs := strings.Fields(strings.TrimSpace(subs[1]))
 		return command{
@@ -48,7 +57,7 @@ func newCommand(
 		}, nil
 	}
 
-	subs = reDisableNext.FindStringSubmatch(comment)
+	subs = ReDisableNext.FindStringSubmatch(comment)
 	if len(subs) == 2 {
 		ruleIDs := strings.Fields(strings.TrimSpace(subs[1]))
 		return command{
@@ -57,7 +66,7 @@ func newCommand(
 		}, nil
 	}
 
-	subs = reDisableThis.FindStringSubmatch(comment)
+	subs = ReDisableThis.FindStringSubmatch(comment)
 	if len(subs) == 2 {
 		ruleIDs := strings.Fields(strings.TrimSpace(subs[1]))
 		return command{

--- a/linter/visitor/extendedAutoDisableVisitor.go
+++ b/linter/visitor/extendedAutoDisableVisitor.go
@@ -1,0 +1,133 @@
+package visitor
+
+import (
+	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/protolint/linter/autodisable"
+	"github.com/yoheimuta/protolint/linter/report"
+)
+
+type extendedAutoDisableVisitor struct {
+	inner     HasExtendedVisitor
+	automator autodisable.PlacementStrategy
+}
+
+func newExtendedAutoDisableVisitor(
+	inner HasExtendedVisitor,
+	ruleID string,
+	protoFilename string,
+	placementType autodisable.PlacementType,
+) (*extendedAutoDisableVisitor, error) {
+	automator, err := autodisable.NewPlacementStrategy(placementType, protoFilename, ruleID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &extendedAutoDisableVisitor{
+		inner:     inner,
+		automator: automator,
+	}, nil
+}
+
+func (v *extendedAutoDisableVisitor) OnStart(p *parser.Proto) error { return v.inner.OnStart(p) }
+func (v *extendedAutoDisableVisitor) Finally() error {
+	err := v.automator.Finalize()
+	if err != nil {
+		return err
+	}
+	return v.inner.Finally()
+}
+func (v *extendedAutoDisableVisitor) Failures() []report.Failure { return v.inner.Failures() }
+
+func (v *extendedAutoDisableVisitor) VisitEmptyStatement(e *parser.EmptyStatement) (next bool) {
+	return v.inner.VisitEmptyStatement(e)
+}
+
+func (v *extendedAutoDisableVisitor) VisitComment(c *parser.Comment) {
+	v.inner.VisitComment(c)
+}
+
+func (v *extendedAutoDisableVisitor) VisitEnum(e *parser.Enum) (next bool) {
+	return v.inner.VisitEnum(e)
+}
+
+func (v *extendedAutoDisableVisitor) VisitEnumField(e *parser.EnumField) (next bool) {
+	return v.doIfFailure(func() bool {
+		return v.inner.VisitEnumField(e)
+	}, func(offset int) {
+		v.automator.Disable(offset, e.Comments, e.InlineComment)
+	})
+}
+
+func (v *extendedAutoDisableVisitor) VisitExtend(m *parser.Extend) (next bool) {
+	return v.inner.VisitExtend(m)
+}
+
+func (v *extendedAutoDisableVisitor) VisitExtensions(m *parser.Extensions) (next bool) {
+	return v.inner.VisitExtensions(m)
+}
+
+func (v *extendedAutoDisableVisitor) VisitField(f *parser.Field) (next bool) {
+	return v.inner.VisitField(f)
+}
+
+func (v *extendedAutoDisableVisitor) VisitGroupField(m *parser.GroupField) (next bool) {
+	return v.inner.VisitGroupField(m)
+}
+
+func (v *extendedAutoDisableVisitor) VisitImport(i *parser.Import) (next bool) {
+	return v.inner.VisitImport(i)
+}
+
+func (v *extendedAutoDisableVisitor) VisitMapField(m *parser.MapField) (next bool) {
+	return v.inner.VisitMapField(m)
+}
+
+func (v *extendedAutoDisableVisitor) VisitMessage(m *parser.Message) (next bool) {
+	return v.inner.VisitMessage(m)
+}
+
+func (v *extendedAutoDisableVisitor) VisitOneof(o *parser.Oneof) (next bool) {
+	return v.inner.VisitOneof(o)
+}
+
+func (v *extendedAutoDisableVisitor) VisitOneofField(o *parser.OneofField) (next bool) {
+	return v.inner.VisitOneofField(o)
+}
+
+func (v *extendedAutoDisableVisitor) VisitOption(o *parser.Option) (next bool) {
+	return v.inner.VisitOption(o)
+}
+
+func (v *extendedAutoDisableVisitor) VisitPackage(p *parser.Package) (next bool) {
+	return v.inner.VisitPackage(p)
+}
+
+func (v *extendedAutoDisableVisitor) VisitReserved(r *parser.Reserved) (next bool) {
+	return v.inner.VisitReserved(r)
+}
+
+func (v *extendedAutoDisableVisitor) VisitRPC(r *parser.RPC) (next bool) {
+	return v.inner.VisitRPC(r)
+}
+
+func (v *extendedAutoDisableVisitor) VisitService(s *parser.Service) (next bool) {
+	return v.inner.VisitService(s)
+}
+
+func (v *extendedAutoDisableVisitor) VisitSyntax(s *parser.Syntax) (next bool) {
+	return v.inner.VisitSyntax(s)
+}
+
+func (v *extendedAutoDisableVisitor) doIfFailure(
+	visit func() bool,
+	disable func(int),
+) bool {
+	prev := v.inner.Failures()
+	next := visit()
+	curr := v.inner.Failures()
+	if len(prev) == len(curr) {
+		return next
+	}
+	disable(curr[len(curr)-1].Pos().Offset)
+	return next
+}

--- a/linter/visitor/extendedDisableRuleVisitor.go
+++ b/linter/visitor/extendedDisableRuleVisitor.go
@@ -9,12 +9,12 @@ import (
 
 // TODO: To work `enable comments` more precisely, this implementation has to be modified.
 type extendedDisableRuleVisitor struct {
-	inner       hasExtendedVisitor
+	inner       HasExtendedVisitor
 	interpreter *disablerule.Interpreter
 }
 
 func newExtendedDisableRuleVisitor(
-	inner hasExtendedVisitor,
+	inner HasExtendedVisitor,
 	ruleID string,
 ) extendedDisableRuleVisitor {
 	interpreter := disablerule.NewInterpreter(ruleID)

--- a/linter/visitor/hasExtendedVisitor.go
+++ b/linter/visitor/hasExtendedVisitor.go
@@ -3,10 +3,12 @@ package visitor
 import (
 	"github.com/yoheimuta/go-protoparser/v4/parser"
 
+	"github.com/yoheimuta/protolint/linter/autodisable"
 	"github.com/yoheimuta/protolint/linter/report"
 )
 
-type hasExtendedVisitor interface {
+// HasExtendedVisitor is a required interface given to RunVisitor.
+type HasExtendedVisitor interface {
 	parser.Visitor
 
 	// OnStart is called when visiting is started.
@@ -19,21 +21,40 @@ type hasExtendedVisitor interface {
 
 // RunVisitor dispatches the call to the visitor.
 func RunVisitor(
-	visitor hasExtendedVisitor,
+	visitor HasExtendedVisitor,
 	proto *parser.Proto,
 	ruleID string,
 ) ([]report.Failure, error) {
-	v := newExtendedDisableRuleVisitor(
-		visitor,
+	return RunVisitorAutoDisable(visitor, proto, ruleID, autodisable.Noop)
+}
+
+// RunVisitorAutoDisable dispatches the call to the visitor.
+func RunVisitorAutoDisable(
+	visitor HasExtendedVisitor,
+	proto *parser.Proto,
+	ruleID string,
+	autodisableType autodisable.PlacementType,
+) ([]report.Failure, error) {
+	// This check is just for existing test cases.
+	protoFilename := ""
+	if proto.Meta != nil {
+		protoFilename = proto.Meta.Filename
+	}
+	autoDisabled, err := newExtendedAutoDisableVisitor(visitor, ruleID, protoFilename, autodisableType)
+	if err != nil {
+		return nil, err
+	}
+	disabled := newExtendedDisableRuleVisitor(
+		autoDisabled,
 		ruleID,
 	)
 
-	if err := v.OnStart(proto); err != nil {
+	if err := disabled.OnStart(proto); err != nil {
 		return nil, err
 	}
-	proto.Accept(v)
-	if err := visitor.Finally(); err != nil {
+	proto.Accept(disabled)
+	if err := disabled.Finally(); err != nil {
 		return nil, err
 	}
-	return v.Failures(), nil
+	return disabled.Failures(), nil
 }


### PR DESCRIPTION
ref. https://github.com/yoheimuta/protolint/issues/269

Currently, only the ENUM_FIELD_NAMES_UPPER_SNAKE_CASE rule turns on this feature.
https://github.com/yoheimuta/protolint/commit/a3e167521ea5be5fc98aa7cfe689e903c0616ebc is a good reference to check out this new feature quickly.