### PR TITLE
Consider rpc trailing comment/292

### DIFF
--- a/_example/proto/issue_292/trailingcomment3.proto
+++ b/_example/proto/issue_292/trailingcomment3.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+service SearchService { // service comment
+  rpc GetAll(GetRequest) returns(GetReply) { // get the global address table
+    option(requestreply.Nats).Subject = "get.addrs";
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/hashicorp/go-hclog v1.2.0
 	github.com/hashicorp/go-plugin v1.4.3
-	github.com/yoheimuta/go-protoparser/v4 v4.6.0
+	github.com/yoheimuta/go-protoparser/v4 v4.7.0
 	google.golang.org/grpc v1.46.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/yoheimuta/go-protoparser/v4 v4.6.0 h1:uvz1e9/5Ihsm4Ku8AJeDImTpirKmIxubZdSn0QJNdnw=
-github.com/yoheimuta/go-protoparser/v4 v4.6.0/go.mod h1:AHNNnSWnb0UoL4QgHPiOAg2BniQceFscPI5X/BZNHl8=
+github.com/yoheimuta/go-protoparser/v4 v4.7.0 h1:80LGfVM25sCoNDD08hv9O0ShQMjoTrIE76j5ON+gq3U=
+github.com/yoheimuta/go-protoparser/v4 v4.7.0/go.mod h1:AHNNnSWnb0UoL4QgHPiOAg2BniQceFscPI5X/BZNHl8=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/internal/addon/rules/rpcsHaveCommentRule.go
+++ b/internal/addon/rules/rpcsHaveCommentRule.go
@@ -57,7 +57,7 @@ func (v *rpcsHaveCommentVisitor) VisitRPC(rpc *parser.RPC) bool {
 	n := rpc.RPCName
 	if v.shouldFollowGolangStyle && !hasGolangStyleComment(rpc.Comments, n) {
 		v.AddFailuref(rpc.Meta.Pos, `RPC %q should have a comment of the form "// %s ..."`, n, n)
-	} else if !hasComments(rpc.Comments, rpc.InlineComment) {
+	} else if !hasComments(rpc.Comments, rpc.InlineComment, rpc.InlineCommentBehindLeftCurly) {
 		v.AddFailuref(rpc.Meta.Pos, `RPC %q should have a comment`, n)
 	}
 	return false

--- a/internal/addon/rules/rpcsHaveCommentRule_test.go
+++ b/internal/addon/rules/rpcsHaveCommentRule_test.go
@@ -45,6 +45,12 @@ func TestRPCsHaveCommentRule_Apply(t *testing.T) {
 									Raw: "// a rpc name.",
 								},
 							},
+							&parser.RPC{
+								RPCName: "RPCName3",
+								InlineCommentBehindLeftCurly: &parser.Comment{
+									Raw: "// a rpc name.",
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
ref. https://github.com/yoheimuta/protolint/issues/292#issuecomment-1305356269

```
(base) ❯ ./protolint -config_path ./_example/proto/issue_292/.notgostyle.yaml ./_example/proto/issue_292
[_example/proto/issue_292/trailingcomment.proto:3:1] Message "xyz" should have a comment
```

```
# Previously
(base) ❯ protolint -config_path ./_example/proto/issue_292/.notgostyle.yaml ./_example/proto/issue_292
[_example/proto/issue_292/trailingcomment.proto:3:1] Message "xyz" should have a comment
[_example/proto/issue_292/trailingcomment3.proto:4:3] RPC "GetAll" should have a comment
```