### PR TITLE
Add a note about homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ brew tap yoheimuta/protolint
 brew install protolint
 ```
 
+Since [homebrew-core](https://github.com/Homebrew/homebrew-core/pkgs/container/core%2Fprotolint) includes `protolint,` you can also install it by just `brew install protolint.` This is the default tap that is installed by default. It's easier, but not maintained by the same author. To keep it updated, I recommend you run `brew tap yoheimuta/protolint` first.
+
+
 ### Via GitHub Releases
 
 You can also download a pre-built binary from this release page:


### PR DESCRIPTION
ref.

- https://github.com/Homebrew/homebrew-core/pull/117858
- https://github.com/Homebrew/homebrew-core/pkgs/container/core%2Fprotolint

```
(base) ❯ brew info protolint
==> protolint: stable 0.42.2 (bottled), HEAD
Pluggable linter and fixer to enforce Protocol Buffer style and conventions
https://github.com/yoheimuta/protolint
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/protolint.rb
License: MIT
==> Dependencies
Build: go ✘
==> Options
--HEAD
        Install HEAD version
==> Analytics
install: 34 (30 days), 34 (90 days), 34 (365 days)
install-on-request: 34 (30 days), 34 (90 days), 34 (365 days)
build-error: 1 (30 days)
```