### PR TITLE
Issue #328 Add deployment to Maven Central

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -42,3 +42,18 @@ jobs:
           # You can't set the default GITHUB_TOKEN because of 403 Resource not accessible to the relevant homebrew repository
           ## See https://github.com/yoheimuta/protolint/actions/runs/3406771906/jobs/5665753996
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Publish package
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.5.1
+          arguments: publish
+        env:
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ out/
 # JIRA plugin
 atlassian-ide-plugin.xml
 
+# Gradle files
+/.gradle
+/build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Contributing
+
+- Fork it
+- Create your feature branch: git checkout -b your-new-feature
+- Commit changes: git commit -m 'Add your feature'
+- Pass all tests
+- Push to the branch: git push origin your-new-feature
+- Submit a pull request
+
+
+## Publish the Maven artifacts
+
+Once a release is done, artifacts will need to be promoted in Maven Central to make them generally available.
+
+1. Head over to https://s01.oss.sonatype.org/#stagingRepositories
+1. Verify the contents of the staging repo and close it
+1. After successful closing (test suite is run), release the repo

--- a/README.md
+++ b/README.md
@@ -459,15 +459,6 @@ I wrote an article comparing various Protocol Buffer Linters, including protolin
 
 - [go-protoparser](https://github.com/yoheimuta/go-protoparser)
 
-## Contributing
-
-- Fork it
-- Create your feature branch: git checkout -b your-new-feature
-- Commit changes: git commit -m 'Add your feature'
-- Pass all tests
-- Push to the branch: git push origin your-new-feature
-- Submit a pull request
-
 ## License
 
 The MIT License (MIT)

--- a/_example/gradle/.gitignore
+++ b/_example/gradle/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/_example/gradle/README.md
+++ b/_example/gradle/README.md
@@ -1,0 +1,5 @@
+# Gradle Example
+
+This is an example project that leverages protoc-gen-protolint. You can test it out by running `gradle generateProto`.
+
+After a successful run, you should see `results.txt` in the _build/generated/source/proto/main/protolint_ directory.

--- a/_example/gradle/build.gradle
+++ b/_example/gradle/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'java'
+    id 'com.google.protobuf' version '0.8.18'
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.19.4"
+    }
+    plugins {
+        protolint {
+            artifact = "io.github.yoheimuta:protoc-gen-protolint:0.43.1"
+        }
+    }
+
+    generateProtoTasks {
+        all().each { task ->
+            task.plugins {
+                protolint {
+                    option 'proto_root=src/main/proto'
+                    option 'output_file=build/generated/source/proto/main/protolint/results.txt'
+                }
+            }
+        }
+    }
+}
+
+repositories {
+    mavenCentral()
+}

--- a/_example/gradle/settings.gradle
+++ b/_example/gradle/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'gradle-demo'

--- a/_example/gradle/src/main/proto/demo.proto
+++ b/_example/gradle/src/main/proto/demo.proto
@@ -1,0 +1,49 @@
+syntax = "proto3";
+// A broken example of the official reference
+// See https://developers.google.com/protocol-buffers/docs/reference/proto3-spec#proto_file
+package examplePb;
+
+option java_package = "com.example.foo";
+
+import 'other.proto';
+import public "new.proto";
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+import "myproject/other_protos.proto";
+import "myproject/main_protos.proto";
+
+enum enumAllowingAlias {
+    option allow_alias = true;
+    UNKNOWN = 0;
+    STARTED = 1;
+    RUNNING = 2 [(custom_option) = "hello world"];
+}
+message outer {
+    option (my_option).a = true;
+    // inner is an inner message.
+    message inner {   // Level 2
+      int64 ival = 1;
+    }
+    repeated inner inner_message = 2;
+    EnumAllowingAlias enum_field =3;
+    map<int32, string> my_map = 4;
+  string reason_for_error = 5;
+  string  end_of_support_version= 6;
+    message AccountForAdmin {}
+  message SpecialEndOfSupport {}
+  required inner inner_message = 7;
+  group Result = 8 {
+    string url = 9;
+  }
+  repeated group Result = 10 {
+  }
+  repeated inner paper = 11;
+  repeated group Regular = 12 {
+  }
+}
+service SearchApi {
+    rpc search (SearchRequest) returns (SearchResponse) {};
+    rpc Search (SearchRequest) returns (SearchResponse) {};
+};

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,95 @@
+plugins {
+    id 'maven-publish'
+    id 'signing'
+}
+
+group = 'io.github.yoheimuta'
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = 'io.github.yoheimuta'
+            artifactId = rootProject.name
+            version = System.getenv("GITHUB_REF_NAME")
+            // Strip "v" from version number
+            if (version.startsWith("v")) {
+                version = version.substring(1)
+            }
+
+            pom {
+                name = groupId + ':' + rootProject.name
+                description = 'protolint is the pluggable linting/fixing utility for Protocol Buffer files (proto2+proto3)'
+                url = 'https://github.com/yoheimuta/protolint'
+                licenses {
+                    license {
+                        name = 'MIT License'
+                        url = 'https://github.com/yoheimuta/protolint/blob/master/LICENSE'
+                    }
+                }
+                developers {
+                    developer {
+                        id = 'yoheimuta'
+                        name = 'yohei yoshimuta'
+                        email = 'yoheimuta@gmail.com'
+                    }
+                }
+                scm {
+                    connection = 'scm:git:git@github.com:yoheimuta/protolint.git'
+                    developerConnection = 'scm:git:git@github.com:yoheimuta/protolint.git'
+                    url = 'https://github.com/yoheimuta/protolint'
+                }
+            }
+
+            //linux 64 arm
+            artifact("$projectDir/dist/protoc-gen-protolint_linux_arm64/protoc-gen-protolint") {
+                classifier 'linux-aarch_64'
+                extension 'exe'
+            }
+            //linux 64 intel
+            artifact("$projectDir/dist/protoc-gen-protolint_linux_amd64_v1/protoc-gen-protolint") {
+                classifier 'linux-x86_64'
+                extension 'exe'
+            }
+            //mac 64 arm
+            artifact("$projectDir/dist/protoc-gen-protolint_darwin_arm64/protoc-gen-protolint") {
+                classifier 'osx-aarch_64'
+                extension 'exe'
+            }
+            //mac 64 intel
+            artifact("$projectDir/dist/protoc-gen-protolint_darwin_amd64_v1/protoc-gen-protolint") {
+                classifier 'osx-x86_64'
+                extension 'exe'
+            }
+            //windows 64 arm
+            artifact("$projectDir/dist/protoc-gen-protolint_windows_arm64/protoc-gen-protolint.exe") {
+                classifier 'windows-aarch_64'
+                extension 'exe'
+            }
+            //windows 64 intel
+            artifact("$projectDir/dist/protoc-gen-protolint_windows_amd64_v1/protoc-gen-protolint.exe") {
+                classifier 'windows-x86_64'
+                extension 'exe'
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "OSSRH"
+            def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+            credentials {
+                username = System.getenv("MAVEN_USERNAME")
+                password = System.getenv("MAVEN_PASSWORD")
+            }
+        }
+    }
+}
+
+signing {
+    def signingKey = project.getProperty('signingKey')
+    def signingPassword = project.getProperty('signingPassword')
+    useInMemoryPgpKeys(signingKey, signingPassword)
+    sign publishing.publications.maven
+}

--- a/cmd/protoc-gen-protolint/README.md
+++ b/cmd/protoc-gen-protolint/README.md
@@ -22,6 +22,11 @@ You can also download a pre-built binary from this release page:
 
 In the downloads section of each release, you can find pre-built binaries in .tar.gz packages.
 
+### Via Maven Central
+
+This plugin is also available on Maven Central. For details about how to use it, check out the [gradle
+example](../../_example/gradle).
+
 ### From Source
 
 The binary can be installed from source if Go is available.

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'protoc-gen-protolint'


### PR DESCRIPTION
This PR aims to give a method of publishing protoc-gen-protolint to maven central.
This aims to address issue https://github.com/yoheimuta/protolint/issues/328.

### Prerequisite
A maven central account is required, and this will have to be added to the repositories secrets, under these variables:

- OSSRH_USERNAME
- OSSRH_TOKEN

This guide can be used to apply for an account: https://central.sonatype.org/publish/publish-guide/#introduction
I have previously done this for testing, and here is an example of the issue I opened: https://issues.sonatype.org/browse/OSSRH-50791

Also signing is done by GPG and requires 2 new secrets to be provided:

- GPG_SIGNING_KEY: The GPG key in armoured form.
- GPG_SIGNING_PASSWORD: The password for signing the artifact.

If a GPG key does not already exist, this guide can be followed: https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key
The value needed for the GPG_SIGNING_KEY secret can be found by:

1. Finding the key name using gpg --list-keys
2. Outputting the key using gpg --export-secret-keys --armor [name] > export.asc
3. Copying the contents of that text file to the secret.

### Implementation
I have used Gradle to publish to Maven, this allowed me to directly upload the artifacts which have been created in other build steps. I attempted to use Maven directly but Maven seemed to want to be more in charge of building and was not allowing the easy output of non-java libraries.

I have added some new steps to github actions which should publish the artifacts after they have been built.

### Usage
With these changes, it should be possible to easily integrate this plugin in projects using google plugins, for example in the gradle plugin. I have included an example of the use in Gradle in the repository.

### Notes
This is very hard to test as this is folded largely into the release and build process.
These changes work in protoc-gen-doc, and I have done a best attempt at adapting these here to publish this repository.
This is due particularly for the need for setup for the release process, and without access to the secrets it is hard to recreate this process in a fork.

### Extra steps which would be needed in the release process
Once a release is done, the aritfacts will appear in the staging repository here: https://s01.oss.sonatype.org/#stagingRepositories
This staging repository can be "closed" which will execute the checks.
If all checks pass (they have in my experiments) the "Release" workflow will become available.

I have put these instructions in the CONTRIBUTING file.