### PR TITLE
Issue #328 Include released version in examples

### DIFF
--- a/_example/gradle/build.gradle
+++ b/_example/gradle/build.gradle
@@ -9,7 +9,7 @@ protobuf {
     }
     plugins {
         protolint {
-            artifact = "io.github.yoheimuta:protoc-gen-protolint:0.43.1"
+            artifact = "io.github.yoheimuta:protoc-gen-protolint:0.43.2"
         }
     }
 


### PR DESCRIPTION
The example provided for gradle used a placeholder version as there wasn't a first release. Now that we have a first release published to maven, we can use the released version and see the example working. So upgrade to the first released version.