### PR TITLE
fix: allow ignored directories that already end in a path separator

### DIFF
--- a/internal/linter/config/directories.go
+++ b/internal/linter/config/directories.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"strings"
+
 	"github.com/yoheimuta/protolint/internal/filepathutil"
 )
 
@@ -13,8 +15,10 @@ func (d Directories) shouldSkipRule(
 	displayPath string,
 ) bool {
 	for _, exclude := range d.Exclude {
-		if filepathutil.HasUnixPathPrefix(displayPath,
-			exclude+string(filepathutil.OSPathSeparator)) {
+		if !strings.HasSuffix(exclude, string(filepathutil.OSPathSeparator)) {
+			exclude += string(filepathutil.OSPathSeparator)
+		}
+		if filepathutil.HasUnixPathPrefix(displayPath, exclude) {
 			return true
 		}
 	}


### PR DESCRIPTION
Previously, a config of the form:

```
lint:
  directories:
    exclude:
      - vendor/
```

would not ignore files in the `vendor` directory, since we would be attempting to match paths that begin with `vendor//`.

To fix this, we only append the path separator when the target does not already end in one.