### PR TITLE
feat: Improve CI/CD usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ The built-in reporter options are:
 - junit
 - json
 - sarif
+- sonar (SonarQube generic issue format)
 - unix
 
 ## Configuring

--- a/README.md
+++ b/README.md
@@ -142,6 +142,58 @@ Jenkins Plugins
 
 - [warnings-ng](https://github.com/jenkinsci/warnings-ng-plugin) and any that use [violatons-lib](https://github.com/tomasbjerre/violations-lib)
 
+### Environment specific output
+
+It is possible to format your linting according to the formatting of the CI/CD environment. The environment must be set using the output format. Currently, the following output is realized:
+
+| Environment | Command Line Value | Description | Example |
+|-------------|--------------------|-------------|---------|
+| Github Actions | ci-gh | [Github Help](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-notice-message) | `::warning file=example.proto,line=10,col=20,title=ENUM_NAMES_UPPER_CAMEL_CASE::EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES` |
+| Azure DevOps | ci-az | [Azure DevOps Help](https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#task-commands) | `##vso[task.logissue type=warning;sourcepath=example.proto;linenumber=10;columnnumber=20;code=ENUM_NAMES_UPPER_CAMEL_CASE;]EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES` |
+| Gitlab CI/CD | ci-glab | Reverse Engineered from Examples | `WARNING: ENUM_NAMES_UPPER_CAMEL_CASE  example.proto(10,20) : EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES` |
+
+You can also use the generic `ci` formatter, which will create a generic problem matcher.
+
+With the `ci-env` value, you can specify the template from the following environment variables:
+
+| Environment Variable | Priority | Meaning |
+|----------------------|----------|---------|
+| PROTOLINT_CIREPORTER_TEMPLATE_STRING | 1 | String containing a Go-template |
+| PROTOLINT_CIREPORTER_TEMPLATE_FILE | 2 | Path to a file containing a Go-template |
+
+The resulting line-feed must not be added, as it will be added automatically.
+
+The following fields are available:
+
+`Severity`
+: The severity as string (either note, warning or error)
+
+`File`
+: Path to the file containing the error
+
+`Line`
+: Line within the `file` containing the error (starting position)
+
+`Column`
+: Column within the `file` containing the error (starting position)
+
+`Rule`
+: The name of the rule that is faulting
+
+`Message`
+: The error message that descibes the error
+
+### Producing an output file and an CI/CD Error stream
+
+You can create a specific output matching your CI/CD environment and also create an output file, e.g. for your static code analysis tools like github CodeQL or SonarQube.
+
+This can be done by adding the `--add-reporter` flag.
+Please note, that the value must be formatted `<reporter-name>:<output-file-path>` (omitting `<` and `>`).
+
+```shell
+$ protolint --reporter ci-gh --add-reporter sarif:/path/to/my/output.sarif.json proto/*.proto
+```
+
 ## Use as a protoc plugin
 
 protolint also maintains a binary [protoc-gen-protolint](cmd/protoc-gen-protolint) that performs the lint functionality as a protoc plugin.

--- a/internal/cmd/subcmds/lint/cmdLint.go
+++ b/internal/cmd/subcmds/lint/cmdLint.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"os"
 	"path/filepath"
 
 	"github.com/hashicorp/go-plugin"
@@ -60,12 +59,6 @@ func NewCmdLint(
 	)
 
 	output := stderr
-	if 0 < len(flags.OutputFilePath) {
-		output, err = os.OpenFile(flags.OutputFilePath, os.O_WRONLY|os.O_CREATE, 0666)
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	return &CmdLint{
 		l:          linter.NewLinter(),
@@ -87,7 +80,7 @@ func (c *CmdLint) Run() osutil.ExitCode {
 		return osutil.ExitInternalFailure
 	}
 
-	err = c.config.reporter.Report(c.output, failures)
+	err = c.config.reporters.ReportWithFallback(c.output, failures)
 	if err != nil {
 		_, _ = fmt.Fprintln(c.stderr, err)
 		return osutil.ExitInternalFailure

--- a/internal/cmd/subcmds/lint/cmdLintConfig.go
+++ b/internal/cmd/subcmds/lint/cmdLintConfig.go
@@ -16,7 +16,7 @@ type CmdLintConfig struct {
 	fixMode         bool
 	autoDisableType autodisable.PlacementType
 	verbose         bool
-	reporter        report.Reporter
+	reporters       report.ReportersWithOutput
 	plugins         []shared.RuleSet
 }
 
@@ -25,12 +25,25 @@ func NewCmdLintConfig(
 	externalConfig config.ExternalConfig,
 	flags Flags,
 ) CmdLintConfig {
+	output := report.WriteToConsole
+	if 0 < len(flags.OutputFilePath) {
+		output = flags.OutputFilePath
+	}
+
+	var reporters report.ReportersWithOutput
+	reporters = append(reporters, *report.NewReporterWithOutput(flags.Reporter, output))
+
+	for _, additionalReporter := range flags.AdditionalReporters {
+		r := *report.NewReporterWithOutput(additionalReporter.reporter, additionalReporter.targetFile)
+		reporters = append(reporters, r)
+	}
+
 	return CmdLintConfig{
 		external:        externalConfig,
 		fixMode:         flags.FixMode,
 		autoDisableType: flags.AutoDisableType,
 		verbose:         flags.Verbose,
-		reporter:        flags.Reporter,
+		reporters:       reporters,
 		plugins:         flags.Plugins,
 	}
 }

--- a/internal/cmd/subcmds/lint/flags.go
+++ b/internal/cmd/subcmds/lint/flags.go
@@ -27,6 +27,7 @@ type Flags struct {
 	Verbose                   bool
 	NoErrorOnUnmatchedPattern bool
 	Plugins                   []shared.RuleSet
+	AdditionalReporters       reporterStreamFlags
 }
 
 // NewFlags creates a new Flags.
@@ -41,6 +42,7 @@ func NewFlags(
 	var rf reporterFlag
 	var af autoDisableFlag
 	var pf subcmds.PluginFlag
+	var rfs reporterStreamFlags
 
 	f.StringVar(
 		&f.ConfigPath,
@@ -93,10 +95,18 @@ func NewFlags(
 		false,
 		"exits with 0 when no file is matched",
 	)
+	f.Var(
+		&rfs,
+		"add-reporter",
+		"Adds a reporter to the list of reporters to use. The format should be 'name of reporter':'Path-To_output_file'",
+	)
 
 	_ = f.Parse(args)
 	if rf.reporter != nil {
 		f.Reporter = rf.reporter
+	}
+	if len(rfs) > 0 {
+		f.AdditionalReporters = rfs
 	}
 	if af.autoDisableType != 0 {
 		f.AutoDisableType = af.autoDisableType

--- a/internal/cmd/subcmds/lint/reporterFlag.go
+++ b/internal/cmd/subcmds/lint/reporterFlag.go
@@ -90,14 +90,19 @@ func (f *reporterFlag) Set(value string) error {
 // GetReporter returns a reporter from the specified key.
 func GetReporter(value string) (report.Reporter, error) {
 	rs := map[string]report.Reporter{
-		"plain": reporters.PlainReporter{},
-		"junit": reporters.JUnitReporter{},
-		"unix":  reporters.UnixReporter{},
-		"json":  reporters.JSONReporter{},
-		"sarif": reporters.SarifReporter{},
+		"plain":   reporters.PlainReporter{},
+		"junit":   reporters.JUnitReporter{},
+		"unix":    reporters.UnixReporter{},
+		"json":    reporters.JSONReporter{},
+		"sarif":   reporters.SarifReporter{},
+		"ci":      reporters.NewCiReporterWithGenericFormat(),
+		"ci-az":   reporters.NewCiReporterForAzureDevOps(),
+		"ci-gh":   reporters.NewCiReporterForGithubActions(),
+		"ci-glab": reporters.NewCiReporterForGitlab(),
+		"ci-env":  reporters.NewCiReporterFromEnv(),
 	}
 	if r, ok := rs[value]; ok {
 		return r, nil
 	}
-	return nil, fmt.Errorf(`available reporters are "plain", "junit", "json", "sarif", and "unix"`)
+	return nil, fmt.Errorf(`available reporters are "plain", "junit", "json", "sarif", and "unix, available reporters for CI/CD are ci, ci-az, ci-gh, ci-glab"`)
 }

--- a/internal/cmd/subcmds/lint/reporterFlag.go
+++ b/internal/cmd/subcmds/lint/reporterFlag.go
@@ -95,6 +95,7 @@ func GetReporter(value string) (report.Reporter, error) {
 		"unix":    reporters.UnixReporter{},
 		"json":    reporters.JSONReporter{},
 		"sarif":   reporters.SarifReporter{},
+		"sonar":   reporters.SonarReporter{},
 		"ci":      reporters.NewCiReporterWithGenericFormat(),
 		"ci-az":   reporters.NewCiReporterForAzureDevOps(),
 		"ci-gh":   reporters.NewCiReporterForGithubActions(),

--- a/internal/linter/report/reporter.go
+++ b/internal/linter/report/reporter.go
@@ -2,11 +2,50 @@ package report
 
 import (
 	"io"
+	"os"
 
 	"github.com/yoheimuta/protolint/linter/report"
+)
+
+const (
+	WriteToConsole string = "-"
 )
 
 // Reporter is responsible to output results in the specific format.
 type Reporter interface {
 	Report(io.Writer, []report.Failure) error
+}
+
+type ReporterWithOutput struct {
+	reporter   Reporter
+	targetFile string
+}
+
+type ReportersWithOutput []ReporterWithOutput
+
+func (ro ReporterWithOutput) ReportWithFallback(w io.Writer, failures []report.Failure) error {
+	if ro.targetFile != WriteToConsole {
+		var err error
+		w, err = os.OpenFile(ro.targetFile, os.O_WRONLY|os.O_CREATE, 0666)
+		if err != nil {
+			return err
+		}
+	}
+
+	return ro.reporter.Report(w, failures)
+}
+
+func (ros ReportersWithOutput) ReportWithFallback(w io.Writer, failures []report.Failure) error {
+	for _, ro := range ros {
+		err := ro.ReportWithFallback(w, failures)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func NewReporterWithOutput(r Reporter, targetFile string) *ReporterWithOutput {
+	return &ReporterWithOutput{r, targetFile}
 }

--- a/internal/linter/report/reporters/ciReporter.go
+++ b/internal/linter/report/reporters/ciReporter.go
@@ -90,7 +90,10 @@ func (c CiReporter) Report(w io.Writer, fs []report.Failure) error {
 		}
 
 		if written > 0 {
-			w.Write([]byte("\n"))
+			_, err = w.Write([]byte("\n"))
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/linter/report/reporters/ciReporter.go
+++ b/internal/linter/report/reporters/ciReporter.go
@@ -1,0 +1,172 @@
+package reporters
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"text/template"
+
+	"github.com/yoheimuta/protolint/linter/report"
+)
+
+type CiPipelineLogTemplate string
+
+const (
+	// problemMatcher provides a generic issue line that can be parsed in a problem matcher or jenkins pipeline
+	problemMatcher CiPipelineLogTemplate = "Protolint {{ .Rule }} ({{ .Severity }}): {{ .File }}[{{ .Line }},{{ .Column }}]: {{ .Message }}"
+	// azureDevOps provides a log message according to https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=bash#task-commands
+	azureDevOps CiPipelineLogTemplate = "{{ if ne \"info\" .Severity }}##vso[task.logissue type={{ .Severity }};sourcepath={{ .File }};linenumber={{ .Line }};columnnumber={{ .Column }};code={{ .Rule }};]{{ .Message }}{{end}}"
+	// gitlabCiCd provides an issue template where the severity is written in upper case. This is matched by the pipeline
+	gitlabCiCd CiPipelineLogTemplate = "{{ .Severity | ToUpper }}: {{ .Rule }}  {{ .File }}({{ .Line }},{{ .Column }}) : {{ .Message }}"
+	// githubActions provides an issue template according to https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-notice-message
+	githubActions CiPipelineLogTemplate = "::{{ if ne \"info\" .Severity }}{{ .Severity }}{{ else }}notice{{ end }} file={{ .File }},line={{ .Line }},col={{ .Column }},title={{ .Rule }}::{{ .Message }}"
+	// empty provides default value for invalid returns
+	empty CiPipelineLogTemplate = ""
+	// env provides a marker for processing CI Templates from environment
+	env CiPipelineLogTemplate = "[ENV]"
+)
+
+type CiReporter struct {
+	pattern CiPipelineLogTemplate
+}
+
+func NewCiReporterForAzureDevOps() CiReporter {
+	return CiReporter{pattern: azureDevOps}
+}
+
+func NewCiReporterForGitlab() CiReporter {
+	return CiReporter{pattern: gitlabCiCd}
+}
+
+func NewCiReporterForGithubActions() CiReporter {
+	return CiReporter{pattern: githubActions}
+}
+
+func NewCiReporterWithGenericFormat() CiReporter {
+	return CiReporter{pattern: problemMatcher}
+}
+
+func NewCiReporterFromEnv() CiReporter {
+	return CiReporter{pattern: env}
+}
+
+type ciReportedFailure struct {
+	Severity string
+	File     string
+	Line     int
+	Column   int
+	Rule     string
+	Message  string
+}
+
+func (c CiReporter) Report(w io.Writer, fs []report.Failure) error {
+	template, err := c.getTemplate()
+	if err != nil {
+		return err
+	}
+
+	for _, failure := range fs {
+		reportedFailure := ciReportedFailure{
+			Severity: getSeverity(failure.Severity()),
+			File:     failure.Pos().Filename,
+			Line:     failure.Pos().Line,
+			Column:   failure.Pos().Column,
+			Rule:     failure.RuleID(),
+			Message:  strings.Trim(strconv.Quote(failure.Message()), `"`), // Ensure message is on a single line without quotes
+		}
+
+		var buffer bytes.Buffer
+		err = template.Execute(&buffer, reportedFailure)
+		if err != nil {
+			return err
+		}
+
+		written, err := w.Write(buffer.Bytes())
+		if err != nil {
+			return err
+		}
+
+		if written > 0 {
+			w.Write([]byte("\n"))
+		}
+	}
+
+	return nil
+}
+
+func getSeverity(s string) string {
+	if s == "note" {
+		return "info"
+	}
+
+	return s
+}
+
+func (c CiReporter) getTemplateString() CiPipelineLogTemplate {
+	if c.pattern == env {
+		template, err := getPatternFromEnv()
+		if err != nil {
+			log.Printf("[ERROR] Failed to process template from Environment: %s\n", err.Error())
+			return problemMatcher
+		}
+
+		if template == empty {
+			return problemMatcher
+		}
+
+		return template
+	}
+	if c.pattern != empty {
+		return c.pattern
+	}
+	return problemMatcher
+}
+
+func (c CiReporter) getTemplate() (*template.Template, error) {
+	toParse := c.getTemplateString()
+
+	toUpper := template.FuncMap{"ToUpper": strings.ToUpper}
+
+	template := template.New("Failure").Funcs(toUpper)
+	evaluate, err := template.Parse(string(toParse))
+	if err != nil {
+		return nil, err
+	}
+	return evaluate, nil
+}
+
+func getPatternFromEnv() (CiPipelineLogTemplate, error) {
+	templateString := os.Getenv("PROTOLINT_CIREPORTER_TEMPLATE_STRING")
+	if templateString != "" {
+		return CiPipelineLogTemplate(templateString), nil
+	}
+
+	templateFile := os.Getenv("PROTOLINT_CIREPORTER_TEMPLATE_FILE")
+	if templateFile != "" {
+		content, err := os.ReadFile(templateFile)
+
+		if err != nil {
+			if os.IsNotExist(err) {
+				log.Printf("[ERROR] Failed to open file %s from 'PROTOLINT_CIREPORTER_TEMPLATE_FILE'. File does not exist.\n", templateFile)
+				log.Println("[WARN] Starting output with default processor.")
+				return empty, nil
+			}
+			if os.IsPermission(err) {
+				log.Printf("[ERROR] Failed to open file %s from 'PROTOLINT_CIREPORTER_TEMPLATE_FILE'. Insufficient permissions.\n", templateFile)
+				log.Println("[WARN] Starting output with default processor.")
+				return empty, nil
+			}
+
+			return empty, err
+		}
+
+		content_string := string(content)
+
+		return CiPipelineLogTemplate(content_string), nil
+	}
+
+	return empty, nil
+}

--- a/internal/linter/report/reporters/ciReporter_test.go
+++ b/internal/linter/report/reporters/ciReporter_test.go
@@ -1,0 +1,457 @@
+package reporters_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
+	"github.com/yoheimuta/protolint/internal/linter/report/reporters"
+	"github.com/yoheimuta/protolint/linter/report"
+	"github.com/yoheimuta/protolint/linter/rule"
+)
+
+type testFiles struct {
+	files []string
+}
+
+type testStruct struct {
+	name          string
+	inputFailures []report.Failure
+	wantOutput    string
+	expectedError error
+	files         testFiles
+}
+
+type testCases struct {
+	oneWarningOneError testStruct
+	onlyErrors         testStruct
+	oneOfEach          testStruct
+}
+
+func makeTestData() testCases {
+	return testCases{
+
+		oneWarningOneError: testStruct{
+			name:          "oneWarningOneError",
+			wantOutput:    "",
+			expectedError: nil,
+			files:         testFiles{},
+			inputFailures: []report.Failure{
+				report.FailureWithSeverityf(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   100,
+						Line:     5,
+						Column:   10,
+					},
+					"ENUM_NAMES_UPPER_CAMEL_CASE",
+					string(rule.SeverityWarning),
+					`EnumField name "fIRST_VALUE" must be CAPITALS_WITH_UNDERSCORES`,
+				),
+				report.FailureWithSeverityf(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   200,
+						Line:     10,
+						Column:   20,
+					},
+					"ENUM_NAMES_UPPER_CAMEL_CASE",
+					string(rule.SeverityError),
+					`EnumField name "SECOND.VALUE" must be CAPITALS_WITH_UNDERSCORES`,
+				),
+			},
+		},
+
+		onlyErrors: testStruct{
+			name:          "onlyErrors",
+			wantOutput:    "",
+			expectedError: nil,
+			files:         testFiles{},
+			inputFailures: []report.Failure{
+				report.FailureWithSeverityf(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   100,
+						Line:     5,
+						Column:   10,
+					},
+					"ENUM_NAMES_UPPER_CAMEL_CASE",
+					string(rule.SeverityError),
+					`EnumField name "fIRST_VALUE" must be CAPITALS_WITH_UNDERSCORES`,
+				),
+				report.FailureWithSeverityf(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   200,
+						Line:     10,
+						Column:   20,
+					},
+					"ENUM_NAMES_UPPER_CAMEL_CASE",
+					string(rule.SeverityError),
+					`EnumField name "SECOND.VALUE" must be CAPITALS_WITH_UNDERSCORES`,
+				),
+				report.FailureWithSeverityf(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   300,
+						Line:     20,
+						Column:   40,
+					},
+					"ENUM_NAMES_UPPER_CAMEL_CASE",
+					string(rule.SeverityError),
+					`EnumField name "third.VALUE" must be CAPITALS_WITH_UNDERSCORES`,
+				),
+			},
+		},
+
+		oneOfEach: testStruct{
+			name:          "oneOfEach",
+			wantOutput:    "",
+			expectedError: nil,
+			files:         testFiles{},
+			inputFailures: []report.Failure{
+				report.FailureWithSeverityf(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   100,
+						Line:     5,
+						Column:   10,
+					},
+					"ENUM_NAMES_UPPER_CAMEL_CASE",
+					string(rule.SeverityNote),
+					`EnumField name "fIRST_VALUE" must be CAPITALS_WITH_UNDERSCORES`,
+				),
+				report.FailureWithSeverityf(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   200,
+						Line:     10,
+						Column:   20,
+					},
+					"ENUM_NAMES_UPPER_CAMEL_CASE",
+					string(rule.SeverityWarning),
+					`EnumField name "SECOND.VALUE" must be CAPITALS_WITH_UNDERSCORES`,
+				),
+				report.FailureWithSeverityf(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   300,
+						Line:     20,
+						Column:   40,
+					},
+					"ENUM_NAMES_UPPER_CAMEL_CASE",
+					string(rule.SeverityError),
+					`EnumField name "third.VALUE" must be CAPITALS_WITH_UNDERSCORES`,
+				),
+			},
+		},
+	}
+}
+
+func TestProblemMatcherReporter_Report(t *testing.T) {
+	initTestCases := makeTestData()
+	initTestCases.oneOfEach.want(`Protolint ENUM_NAMES_UPPER_CAMEL_CASE (info): example.proto[5,10]: EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+Protolint ENUM_NAMES_UPPER_CAMEL_CASE (warning): example.proto[10,20]: EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+Protolint ENUM_NAMES_UPPER_CAMEL_CASE (error): example.proto[20,40]: EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.oneWarningOneError.want(`Protolint ENUM_NAMES_UPPER_CAMEL_CASE (warning): example.proto[5,10]: EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+Protolint ENUM_NAMES_UPPER_CAMEL_CASE (error): example.proto[10,20]: EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.onlyErrors.want(`Protolint ENUM_NAMES_UPPER_CAMEL_CASE (error): example.proto[5,10]: EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+Protolint ENUM_NAMES_UPPER_CAMEL_CASE (error): example.proto[10,20]: EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+Protolint ENUM_NAMES_UPPER_CAMEL_CASE (error): example.proto[20,40]: EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+
+	tests := initTestCases.tests()
+
+	reporter := reporters.NewCiReporterWithGenericFormat()
+	run_tests(t, tests, reporter)
+}
+
+func TestAzureDevOpsMatcherReporter_Report(t *testing.T) {
+	initTestCases := makeTestData()
+	initTestCases.oneOfEach.want(`##vso[task.logissue type=warning;sourcepath=example.proto;linenumber=10;columnnumber=20;code=ENUM_NAMES_UPPER_CAMEL_CASE;]EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+##vso[task.logissue type=error;sourcepath=example.proto;linenumber=20;columnnumber=40;code=ENUM_NAMES_UPPER_CAMEL_CASE;]EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.oneWarningOneError.want(`##vso[task.logissue type=warning;sourcepath=example.proto;linenumber=5;columnnumber=10;code=ENUM_NAMES_UPPER_CAMEL_CASE;]EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+##vso[task.logissue type=error;sourcepath=example.proto;linenumber=10;columnnumber=20;code=ENUM_NAMES_UPPER_CAMEL_CASE;]EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.onlyErrors.want(`##vso[task.logissue type=error;sourcepath=example.proto;linenumber=5;columnnumber=10;code=ENUM_NAMES_UPPER_CAMEL_CASE;]EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+##vso[task.logissue type=error;sourcepath=example.proto;linenumber=10;columnnumber=20;code=ENUM_NAMES_UPPER_CAMEL_CASE;]EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+##vso[task.logissue type=error;sourcepath=example.proto;linenumber=20;columnnumber=40;code=ENUM_NAMES_UPPER_CAMEL_CASE;]EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+
+	tests := initTestCases.tests()
+
+	reporter := reporters.NewCiReporterForAzureDevOps()
+	run_tests(t, tests, reporter)
+}
+func TestGithubActionMatcherReporter_Report(t *testing.T) {
+	initTestCases := makeTestData()
+	initTestCases.oneOfEach.want(`::notice file=example.proto,line=5,col=10,title=ENUM_NAMES_UPPER_CAMEL_CASE::EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+::warning file=example.proto,line=10,col=20,title=ENUM_NAMES_UPPER_CAMEL_CASE::EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+::error file=example.proto,line=20,col=40,title=ENUM_NAMES_UPPER_CAMEL_CASE::EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.oneWarningOneError.want(`::warning file=example.proto,line=5,col=10,title=ENUM_NAMES_UPPER_CAMEL_CASE::EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+::error file=example.proto,line=10,col=20,title=ENUM_NAMES_UPPER_CAMEL_CASE::EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.onlyErrors.want(`::error file=example.proto,line=5,col=10,title=ENUM_NAMES_UPPER_CAMEL_CASE::EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+::error file=example.proto,line=10,col=20,title=ENUM_NAMES_UPPER_CAMEL_CASE::EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+::error file=example.proto,line=20,col=40,title=ENUM_NAMES_UPPER_CAMEL_CASE::EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+
+	tests := initTestCases.tests()
+
+	reporter := reporters.NewCiReporterForGithubActions()
+	run_tests(t, tests, reporter)
+}
+func TestGitlabCiCdMatcherReporter_Report(t *testing.T) {
+	initTestCases := makeTestData()
+	initTestCases.oneOfEach.want(`INFO: ENUM_NAMES_UPPER_CAMEL_CASE  example.proto(5,10) : EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+WARNING: ENUM_NAMES_UPPER_CAMEL_CASE  example.proto(10,20) : EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+ERROR: ENUM_NAMES_UPPER_CAMEL_CASE  example.proto(20,40) : EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.oneWarningOneError.want(`WARNING: ENUM_NAMES_UPPER_CAMEL_CASE  example.proto(5,10) : EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+ERROR: ENUM_NAMES_UPPER_CAMEL_CASE  example.proto(10,20) : EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.onlyErrors.want(`ERROR: ENUM_NAMES_UPPER_CAMEL_CASE  example.proto(5,10) : EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+ERROR: ENUM_NAMES_UPPER_CAMEL_CASE  example.proto(10,20) : EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+ERROR: ENUM_NAMES_UPPER_CAMEL_CASE  example.proto(20,40) : EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+
+	tests := initTestCases.tests()
+	reporter := reporters.NewCiReporterForGitlab()
+	run_tests(t, tests, reporter)
+}
+
+func TestEnvMatcherReporterFromTemplateString_Report(t *testing.T) {
+	t.Setenv("PROTOLINT_CIREPORTER_TEMPLATE_STRING", "{{ .Severity }}@{{ .File }}[{{ .Line }},{{ .Column }}] triggered rule {{ .Rule }} with message {{ .Message }}")
+	initTestCases := makeTestData()
+	initTestCases.oneOfEach.want(`info@example.proto[5,10] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+warning@example.proto[10,20] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+error@example.proto[20,40] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.oneWarningOneError.want(`warning@example.proto[5,10] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+error@example.proto[10,20] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.onlyErrors.want(`error@example.proto[5,10] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+error@example.proto[10,20] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+error@example.proto[20,40] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+
+	tests := initTestCases.tests()
+	reporter := reporters.NewCiReporterFromEnv()
+	run_tests(t, tests, reporter)
+}
+
+func TestEnvMatcherReporterFromTemplateFile_Report(t *testing.T) {
+	initTestCases := makeTestData()
+	initTestCases.oneOfEach.files.appendFile(t, "0oneOfEach.template", "[fromfile:0oneOfEach.template] {{ .Severity }}@{{ .File }}[{{ .Line }},{{ .Column }}] triggered rule {{ .Rule }} with message {{ .Message }}")
+	initTestCases.oneOfEach.want(`[fromfile:0oneOfEach.template] info@example.proto[5,10] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+[fromfile:0oneOfEach.template] warning@example.proto[10,20] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+[fromfile:0oneOfEach.template] error@example.proto[20,40] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.oneWarningOneError.files.appendFile(t, "0oneWarningOneError.template", "[fromfile:0oneWarningOneError.template] {{ .Severity }}@{{ .File }}[{{ .Line }},{{ .Column }}] triggered rule {{ .Rule }} with message {{ .Message }}")
+	initTestCases.oneWarningOneError.want(`[fromfile:0oneWarningOneError.template] warning@example.proto[5,10] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+[fromfile:0oneWarningOneError.template] error@example.proto[10,20] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.onlyErrors.files.appendFile(t, "0onlyErrors.template", "[fromfile:0onlyErrors.template] {{ .Severity }}@{{ .File }}[{{ .Line }},{{ .Column }}] triggered rule {{ .Rule }} with message {{ .Message }}")
+	initTestCases.onlyErrors.want(`[fromfile:0onlyErrors.template] error@example.proto[5,10] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+[fromfile:0onlyErrors.template] error@example.proto[10,20] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+[fromfile:0onlyErrors.template] error@example.proto[20,40] triggered rule ENUM_NAMES_UPPER_CAMEL_CASE with message EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+
+	tests := initTestCases.tests()
+	reporter := reporters.NewCiReporterFromEnv()
+	run_tests(t, tests, reporter)
+}
+
+func TestEnvMatcherReporterFromNonExistingTemplateFile_Report(t *testing.T) {
+	t.Setenv("PROTOLINT_CIREPORTER_TEMPLATE_FILE", filepath.Join(t.TempDir(), "does.not.exist"))
+	initTestCases := makeTestData()
+	initTestCases.oneOfEach.want(`Protolint ENUM_NAMES_UPPER_CAMEL_CASE (info): example.proto[5,10]: EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+Protolint ENUM_NAMES_UPPER_CAMEL_CASE (warning): example.proto[10,20]: EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+Protolint ENUM_NAMES_UPPER_CAMEL_CASE (error): example.proto[20,40]: EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.oneWarningOneError.want(`Protolint ENUM_NAMES_UPPER_CAMEL_CASE (warning): example.proto[5,10]: EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+Protolint ENUM_NAMES_UPPER_CAMEL_CASE (error): example.proto[10,20]: EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.onlyErrors.want(`Protolint ENUM_NAMES_UPPER_CAMEL_CASE (error): example.proto[5,10]: EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+Protolint ENUM_NAMES_UPPER_CAMEL_CASE (error): example.proto[10,20]: EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+Protolint ENUM_NAMES_UPPER_CAMEL_CASE (error): example.proto[20,40]: EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+
+	tests := initTestCases.tests()
+	reporter := reporters.NewCiReporterFromEnv()
+	run_tests(t, tests, reporter)
+}
+
+func TestEnvMatcherReporterFromUnallowedTemplateFile_Report(t *testing.T) {
+	tplFile := filepath.Join(t.TempDir(), "does.exist")
+	t.Setenv("PROTOLINT_CIREPORTER_TEMPLATE_FILE", tplFile)
+	t.Cleanup(func() {
+		if _, err := os.Stat(tplFile); os.IsNotExist(err) {
+			t.Logf("File %s already deleted", tplFile)
+		}
+
+		err := os.Remove(tplFile)
+		if err != nil {
+			t.Errorf("ERROR while cleaning up file %s: %v", tplFile, err)
+		}
+	})
+	file, err := os.Create(tplFile)
+	if err != nil {
+		t.Errorf("Failed to create temp file: %v", err)
+	}
+	file.Write([]byte("[fromfile:does.exist] {{ .Severity }}@{{ .File }}[{{ .Line }},{{ .Column }}] triggered rule {{ .Rule }} with message {{ .Message }}"))
+	err = file.Close()
+	if err != nil {
+		t.Errorf("Failed to create temp file (error while closing): %v", err)
+	}
+	err = os.Chmod(tplFile, 0200)
+	if err != nil {
+		t.Errorf("Failed to remove read permissions: %v", err)
+	}
+
+	initTestCases := makeTestData()
+	initTestCases.oneOfEach.want(`Protolint ENUM_NAMES_UPPER_CAMEL_CASE (info): example.proto[5,10]: EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+Protolint ENUM_NAMES_UPPER_CAMEL_CASE (warning): example.proto[10,20]: EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+Protolint ENUM_NAMES_UPPER_CAMEL_CASE (error): example.proto[20,40]: EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.oneWarningOneError.want(`Protolint ENUM_NAMES_UPPER_CAMEL_CASE (warning): example.proto[5,10]: EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+Protolint ENUM_NAMES_UPPER_CAMEL_CASE (error): example.proto[10,20]: EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+	initTestCases.onlyErrors.want(`Protolint ENUM_NAMES_UPPER_CAMEL_CASE (error): example.proto[5,10]: EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES
+Protolint ENUM_NAMES_UPPER_CAMEL_CASE (error): example.proto[10,20]: EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+Protolint ENUM_NAMES_UPPER_CAMEL_CASE (error): example.proto[20,40]: EnumField name \"third.VALUE\" must be CAPITALS_WITH_UNDERSCORES
+`)
+
+	tests := initTestCases.tests()
+	reporter := reporters.NewCiReporterFromEnv()
+	run_tests(t, tests, reporter)
+}
+
+func TestEnvMatcherReporterFromErroneousTemplateFile_ReportTestEnvMatcherReporterFromErroneousTemplateString_Report(t *testing.T) {
+	initTestCases := makeTestData()
+	initTestCases.oneOfEach.files.appendFile(t, "1oneOfEach.template", "[fromfile:1oneOfEach.template] {{ .Severit }}@{{ .Fil }}[{{ .Lne }},{{ .Colum }}] triggered rule {{ .ule }} with message {{ .Msg }}")
+	initTestCases.oneOfEach.expectError(`template: Failure:1:34: executing "Failure" at <.Severit>: can't evaluate field Severit in type reporters.ciReportedFailure`)
+
+	initTestCases.oneWarningOneError.files.appendFile(t, "1oneWarningOneError.template", "[fromfile:1oneWarningOneError.template] {{ .Severit }}@{{ .Fil }}[{{ .Lne }},{{ .Colum }}] triggered rule {{ .ule }} with message {{ .Msg }}")
+	initTestCases.oneWarningOneError.expectError(`template: Failure:1:43: executing "Failure" at <.Severit>: can't evaluate field Severit in type reporters.ciReportedFailure`)
+
+	initTestCases.onlyErrors.files.appendFile(t, "1onlyErrors.template", "[fromfile:1onlyErrors.template] {{ .Severit }}@{{ .Fil }}[{{ .Lne }},{{ .Colum }}] triggered rule {{ .ule }} with message {{ .Msg }}")
+	initTestCases.onlyErrors.expectError(`template: Failure:1:35: executing "Failure" at <.Severit>: can't evaluate field Severit in type reporters.ciReportedFailure`)
+
+	tests := initTestCases.tests()
+	reporter := reporters.NewCiReporterFromEnv()
+	run_tests(t, tests, reporter)
+}
+
+func TestEnvMatcherReporterFromErroneousTemplateString_Report(t *testing.T) {
+	t.Setenv("PROTOLINT_CIREPORTER_TEMPLATE_STRING", "{{ .Severit }}@{{ .Fil }}[{{ .Lne }},{{ .Colum }}] triggered rule {{ .ule }} with message {{ .Msg }}")
+	initTestCases := makeTestData()
+	initTestCases.oneOfEach.expectError(`template: Failure:1:3: executing "Failure" at <.Severit>: can't evaluate field Severit in type reporters.ciReportedFailure`)
+	initTestCases.oneWarningOneError.expectError(`template: Failure:1:3: executing "Failure" at <.Severit>: can't evaluate field Severit in type reporters.ciReportedFailure`)
+	initTestCases.onlyErrors.expectError(`template: Failure:1:3: executing "Failure" at <.Severit>: can't evaluate field Severit in type reporters.ciReportedFailure`)
+
+	tests := initTestCases.tests()
+	reporter := reporters.NewCiReporterFromEnv()
+	run_tests(t, tests, reporter)
+}
+
+func run_tests(t *testing.T, tests []testStruct, r reporters.CiReporter) {
+	if len(tests) == 0 {
+		t.SkipNow()
+	}
+	for _, test := range tests {
+		test := test
+		t.Cleanup(func() { test.cleanUp(t) })
+		t.Run(test.name, func(t *testing.T) {
+			if len(test.files.files) > 0 {
+				t.Setenv("PROTOLINT_CIREPORTER_TEMPLATE_FILE", test.files.files[0])
+			}
+
+			buf := &bytes.Buffer{}
+			err := r.Report(buf, test.inputFailures)
+			test.cleanUp(t)
+			if err != nil {
+				isExpectedError := false
+				if test.expectedError != nil {
+					isExpectedError = err.Error() == test.expectedError.Error()
+				}
+
+				if !isExpectedError {
+					t.Errorf("got err %v, but want %v", err, test.expectedError)
+					return
+				} else {
+					t.Logf("Wanted %v, got %v", test.expectedError, err)
+				}
+			}
+			if buf.String() != test.wantOutput {
+				t.Errorf(`  got 
+%s
+, but want
+%s`, buf.String(), test.wantOutput)
+			}
+		})
+	}
+}
+
+func (ts testStruct) cleanUp(t *testing.T) {
+	ts.files.cleanUp(t)
+}
+
+func (tf testFiles) cleanUp(t *testing.T) {
+	for _, file := range tf.files {
+
+		if _, err := os.Stat(file); os.IsNotExist(err) {
+			t.Logf("File %s already deleted", file)
+			continue
+		}
+
+		err := os.Remove(file)
+		if err != nil {
+			t.Errorf("ERROR while cleaning up file %s: %v", file, err)
+		}
+	}
+}
+
+func (tf *testFiles) appendFile(t *testing.T, fileName string, fileContent string) {
+	filePath := filepath.Join(t.TempDir(), fileName)
+	file, err := os.Create(filePath)
+	if err != nil {
+		t.Errorf("Failed to create file %s: %v", filePath, err)
+		return
+	}
+
+	defer file.Close()
+	_, err = file.WriteString(fileContent)
+	if err != nil {
+		t.Errorf("Failed to content to file %s: %v", filePath, err)
+		return
+	}
+
+	tf.files = append(tf.files, filePath)
+}
+
+func (ts *testStruct) want(input string) {
+	ts.wantOutput = input
+}
+
+func (ts *testStruct) expectError(err string) {
+	ts.expectedError = fmt.Errorf(err)
+	ts.want("")
+}
+
+func (td testCases) tests() []testStruct {
+	var allCases []testStruct
+
+	allCases = append(allCases, td.oneOfEach)
+	allCases = append(allCases, td.oneWarningOneError)
+	allCases = append(allCases, td.onlyErrors)
+
+	return allCases
+}

--- a/internal/linter/report/reporters/ciReporter_test.go
+++ b/internal/linter/report/reporters/ciReporter_test.go
@@ -306,7 +306,10 @@ func TestEnvMatcherReporterFromUnallowedTemplateFile_Report(t *testing.T) {
 	if err != nil {
 		t.Errorf("Failed to create temp file: %v", err)
 	}
-	file.Write([]byte("[fromfile:does.exist] {{ .Severity }}@{{ .File }}[{{ .Line }},{{ .Column }}] triggered rule {{ .Rule }} with message {{ .Message }}"))
+	_, err = file.Write([]byte("[fromfile:does.exist] {{ .Severity }}@{{ .File }}[{{ .Line }},{{ .Column }}] triggered rule {{ .Rule }} with message {{ .Message }}"))
+	if err != nil {
+		t.Errorf("Failed to write temp file: %v", err)
+	}
 	err = file.Close()
 	if err != nil {
 		t.Errorf("Failed to create temp file (error while closing): %v", err)
@@ -427,7 +430,14 @@ func (tf *testFiles) appendFile(t *testing.T, fileName string, fileContent strin
 		return
 	}
 
-	defer file.Close()
+	defer func(td *testing.T) {
+		err = file.Close()
+		if err != nil {
+			td.Errorf("Failed to content to file %s: %v", filePath, err)
+			return
+		}
+	}(t)
+
 	_, err = file.WriteString(fileContent)
 	if err != nil {
 		t.Errorf("Failed to content to file %s: %v", filePath, err)

--- a/internal/linter/report/reporters/sonarReporter.go
+++ b/internal/linter/report/reporters/sonarReporter.go
@@ -1,0 +1,86 @@
+package reporters
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/yoheimuta/protolint/linter/report"
+)
+
+const (
+	protolintSonarEngineId  string = "protolint"
+	protolintSonarIssueType string = "CODE_SMELL"
+	severityError           string = "MAJOR"
+	severityWarn            string = "MINOR"
+	severityNote            string = "INFO"
+)
+
+type SonarReporter struct {
+}
+
+// for details refer to https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/importing-external-issues/generic-issue-import-format/
+
+type sonarTextRange struct {
+	StartLine   int `json:"startLine"`
+	StartColumn int `json:"startColumn"`
+}
+
+type sonarLocation struct {
+	Message   string         `json:"message"`
+	FilePath  string         `json:"filePath"`
+	TextRange sonarTextRange `json:"textRange"`
+}
+
+type sonarIssue struct {
+	EngineId        string        `json:"engineId"`
+	RuleId          string        `json:"ruleId"`
+	PrimaryLocation sonarLocation `json:"primaryLocation"`
+	Severity        string        `json:"severity"`
+	IssueType       string        `json:"issueType"`
+}
+
+func (s SonarReporter) Report(w io.Writer, fs []report.Failure) error {
+	var issues []sonarIssue
+	for _, f := range fs {
+		issue := sonarIssue{
+			EngineId:  protolintSonarEngineId,
+			RuleId:    f.RuleID(),
+			IssueType: protolintSonarIssueType,
+			Severity:  getSonarSeverity(f.Severity()),
+			PrimaryLocation: sonarLocation{
+				Message:  f.Message(),
+				FilePath: f.Pos().Filename,
+				TextRange: sonarTextRange{
+					StartLine:   f.Pos().Line,
+					StartColumn: f.Pos().Column,
+				},
+			},
+		}
+
+		issues = append(issues, issue)
+	}
+
+	bs, err := json.MarshalIndent(issues, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(bs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getSonarSeverity(severity string) string {
+	if severity == "warn" {
+		return severityWarn
+	}
+
+	if severity == "note" {
+		return severityNote
+	}
+
+	return severityError
+}

--- a/internal/linter/report/reporters/sonarReporter_test.go
+++ b/internal/linter/report/reporters/sonarReporter_test.go
@@ -1,0 +1,90 @@
+package reporters_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
+
+	"github.com/yoheimuta/protolint/internal/linter/report/reporters"
+	"github.com/yoheimuta/protolint/linter/report"
+)
+
+func TestSonarReporter_Report(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputFailures []report.Failure
+		wantOutput    string
+	}{
+		{
+			name: "Prints failures in Sonar format",
+			inputFailures: []report.Failure{
+				report.Failuref(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   100,
+						Line:     5,
+						Column:   10,
+					},
+					"ENUM_NAMES_UPPER_CAMEL_CASE",
+					`EnumField name "fIRST_VALUE" must be CAPITALS_WITH_UNDERSCORES`,
+				),
+				report.Failuref(
+					meta.Position{
+						Filename: "example.proto",
+						Offset:   200,
+						Line:     10,
+						Column:   20,
+					},
+					"ENUM_NAMES_UPPER_CAMEL_CASE",
+					`EnumField name "SECOND.VALUE" must be CAPITALS_WITH_UNDERSCORES`,
+				),
+			},
+			wantOutput: `[
+  {
+    "engineId": "protolint",
+    "ruleId": "ENUM_NAMES_UPPER_CAMEL_CASE",
+    "primaryLocation": {
+      "message": "EnumField name \"fIRST_VALUE\" must be CAPITALS_WITH_UNDERSCORES",
+      "filePath": "example.proto",
+      "textRange": {
+        "startLine": 5,
+        "startColumn": 10
+      }
+    },
+    "severity": "MAJOR",
+    "issueType": "CODE_SMELL"
+  },
+  {
+    "engineId": "protolint",
+    "ruleId": "ENUM_NAMES_UPPER_CAMEL_CASE",
+    "primaryLocation": {
+      "message": "EnumField name \"SECOND.VALUE\" must be CAPITALS_WITH_UNDERSCORES",
+      "filePath": "example.proto",
+      "textRange": {
+        "startLine": 10,
+        "startColumn": 20
+      }
+    },
+    "severity": "MAJOR",
+    "issueType": "CODE_SMELL"
+  }
+]`,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			err := reporters.SonarReporter{}.Report(buf, test.inputFailures)
+			if err != nil {
+				t.Errorf("got err %v, but want nil", err)
+				return
+			}
+			if buf.String() != test.wantOutput {
+				t.Errorf("got %s, but want %s", buf.String(), test.wantOutput)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- [X] Added ability to use `--add-reporter` to specify another report to an output file
- [X] Added different reporters for various CI/CD Systems
  - [X] Added support for github actions
  - [X] Added support for gitlab CI/CD
  - [X] Added support for Azure DevOps Pipelines
  - [X] Added ability to customize CI/CD output, if another CI/CD System like drone CI or  gitea uses a special format
- [X] Added tests for CI/CD use cases
- [X] Updated documentation
- [x] Added new format SonarQube Generic Issues

Closes #336 