### PR TITLE
fix: Make ToSnakecase correct in the way converting from camel-case strings starting with a 2-letter abbreviation

### DIFF
--- a/_testdata/rules/enumFieldNamesUpperSnakeCase/disable_next.proto
+++ b/_testdata/rules/enumFieldNamesUpperSnakeCase/disable_next.proto
@@ -10,5 +10,5 @@ enum enumAlias {
     // protolint:disable:next ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
     started_lap = 1;
     // protolint:disable:next ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
-    RUNNINGlapUntil = 2 [(custom_option) = "hello world"];
+    RUNNINGLapUntil = 2 [(custom_option) = "hello world"];
 }

--- a/_testdata/rules/enumFieldNamesUpperSnakeCase/disable_this.proto
+++ b/_testdata/rules/enumFieldNamesUpperSnakeCase/disable_this.proto
@@ -7,5 +7,5 @@ enum enum {
 
 enum enumAlias {
     started_lap = 1; // protolint:disable:this ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
-    RUNNINGlapUntil = 2 [(custom_option) = "hello world"]; // protolint:disable:this ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
+    RUNNINGLapUntil = 2 [(custom_option) = "hello world"]; // protolint:disable:this ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
 }

--- a/_testdata/rules/enumFieldNamesUpperSnakeCase/invalid.proto
+++ b/_testdata/rules/enumFieldNamesUpperSnakeCase/invalid.proto
@@ -7,5 +7,5 @@ enum enum {
 
 enum enumAlias {
     started_lap = 1;
-    RUNNINGlapUntil = 2 [(custom_option) = "hello world"];
+    RUNNINGLapUntil = 2 [(custom_option) = "hello world"];
 }

--- a/_testdata/rules/enumFieldNamesUpperSnakeCase/upperSnakeCase.proto
+++ b/_testdata/rules/enumFieldNamesUpperSnakeCase/upperSnakeCase.proto
@@ -7,5 +7,5 @@ enum enum {
 
 enum enumAlias {
     STARTED_LAP = 1;
-    RUNNINGLAP_UNTIL = 2 [(custom_option) = "hello world"];
+    RUNNING_LAP_UNTIL = 2 [(custom_option) = "hello world"];
 }

--- a/internal/addon/rules/enumFieldNamesPrefixRule_test.go
+++ b/internal/addon/rules/enumFieldNamesPrefixRule_test.go
@@ -72,6 +72,23 @@ func TestEnumFieldNamesPrefixRule_Apply(t *testing.T) {
 			},
 		},
 		{
+			name: "no failures for proto with valid enum field names even when its camel-case string starts with a 2-letter abbreviation",
+			inputProto: &parser.Proto{
+				ProtoBody: []parser.Visitee{
+					&parser.Service{},
+					&parser.Enum{
+						EnumName: "ITDepartmentRegion",
+						EnumBody: []parser.Visitee{
+							&parser.EnumField{
+								Ident:  "IT_DEPARTMENT_REGION_UNSPECIFIED",
+								Number: "0",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "failures for proto with invalid enum field names",
 			inputProto: &parser.Proto{
 				ProtoBody: []parser.Visitee{

--- a/linter/strs/strs.go
+++ b/linter/strs/strs.go
@@ -152,13 +152,13 @@ func ToLowerCamelCase(s string) string {
 func toSnake(s string) string {
 	output := ""
 	s = strings.TrimSpace(s)
-	priorLower := false
-	for _, c := range s {
-		if priorLower && isUpper(c) {
-			output += "_"
+	priorUpper := false
+	for i, c := range s {
+		if priorUpper && isLower(c) && 1 < i {
+			output = output[:len(output)-1] + "_" + output[len(output)-1:]
 		}
 		output += string(c)
-		priorLower = isLower(c)
+		priorUpper = isUpper(c)
 	}
 	return output
 }

--- a/linter/strs/strs_test.go
+++ b/linter/strs/strs_test.go
@@ -208,7 +208,8 @@ func TestSplitCamelCaseWord(t *testing.T) {
 			name:  "input consists of words with continuous upper letters",
 			input: "ACCOUNTStatusException",
 			want: []string{
-				"ACCOUNTStatus",
+				"ACCOUNT",
+				"Status",
 				"Exception",
 			},
 		},
@@ -250,6 +251,11 @@ func TestToUpperSnakeCase(t *testing.T) {
 			name:  "input consists of words without an initial capital",
 			input: "accountStatus",
 			want:  "ACCOUNT_STATUS",
+		},
+		{
+			name:  "convert from camel-case strings starting with a 2-letter abbreviation #341",
+			input: "ITDepartmentRegion",
+			want:  "IT_DEPARTMENT_REGION",
 		},
 	}
 


### PR DESCRIPTION
ref. https://github.com/yoheimuta/protolint/issues/341