### PR TITLE
fix: protolint:disable MAX_LINE_LENGTH works with a disable comment that has a different ruleID

### DIFF
--- a/linter/disablerule/interpreter.go
+++ b/linter/disablerule/interpreter.go
@@ -75,6 +75,9 @@ func (i *Interpreter) CallEachIfValid(
 			shouldSkip = false
 			continue
 		}
+		if i.isDisabled {
+			continue
+		}
 
 		f(index, line)
 	}

--- a/linter/disablerule/interpreter_test.go
+++ b/linter/disablerule/interpreter_test.go
@@ -380,6 +380,19 @@ func TestInterpreter_CallEachIfValid(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "protolint:disable doesn't collide with protolint:disable that has a different ruleID",
+			inputRuleID: "MAX_LINE_LENGTH",
+			inputLines: []string{
+				`// protolint:disable MAX_LINE_LENGTH`,
+				`syntax = "proto3";`,
+				`/** Schnufte test enumeration. */`,
+				`enum TestEnum {`,
+				`  TEST_ENUM_UNSPECIFIED = 0; // Unspecified.`,
+				`  FOO = 1;                               // protolint:disable:this ENUM_FIELD_NAMES_PREFIX`,
+				`}`,
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
ref. https://github.com/yoheimuta/protolint/issues/345