### PR TITLE
fix: NPM packages cannot be published

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -39,4 +39,5 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish
+        working-directory: ./bdist/js
         if: ${{ env.NODE_AUTH_TOKEN != '' }}


### PR DESCRIPTION
in #356 it was mentioned, that the upload did not
work.
First issue seems to be, that the package.json cannot be found. The root cause seems to be, that the
working directory is not correct.

This should work