### PR TITLE
ci: add ossf/scorecard github action

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,0 +1,55 @@
+---
+name: Scorecards supply-chain security
+on:
+  # Only the default branch is supported.
+  branch_protection_rule:
+  schedule:
+    - cron: 44 9 * * 4
+  push:
+    branches: [master]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecards analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Used to receive a badge.
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846  # tag=v3.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d  # tag=v2.0.6
+        with:
+          results_file: results.sarif
+          results_format: sarif
+
+          # Publish the results for public repositories to enable scorecard badges. For more details, see
+          # https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless
+          # of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: Upload artifact
+        uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535  # tag=v3.0.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard.
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@5f532563584d71fdef14ee64d17bafb34f751ce5  # tag=v1.0.26
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![Go Report Card](https://goreportcard.com/badge/github.com/yoheimuta/protolint)](https://goreportcard.com/report/github.com/yoheimuta/protolint)
 [![License](http://img.shields.io/:license-mit-blue.svg)](https://github.com/yoheimuta/protolint/blob/master/LICENSE)
 [![Docker](https://img.shields.io/docker/pulls/yoheimuta/protolint)](https://hub.docker.com/r/yoheimuta/protolint)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/yoheimuta/protolint/badge)](https://api.securityscorecards.dev/projects/github.com/yoheimuta/protolint)
 
 protolint is the pluggable linting/fixing utility for Protocol Buffer files (proto2+proto3):
 
@@ -119,7 +120,7 @@ protolint lint -config_path=path/to/your_protolint.yaml . # use path/to/your_pro
 protolint lint -config_dir_path=path/to .   # search path/to for .protolint.yaml
 protolint lint -fix .                       # automatically fix some of the problems reported by some rules
 protolint lint -fix -auto_disable=next .    # this is preferable when you want to fix problems while maintaining the compatibility. Automatically fix some problems and insert disable comments to the other problems. The available values are next and this.
-protolint lint -auto_disable=next .         # automatically insert disable comments to the other problems. 
+protolint lint -auto_disable=next .         # automatically insert disable comments to the other problems.
 protolint lint -v .                         # with verbose output to investigate the parsing error
 protolint lint -no-error-on-unmatched-pattern . # exits with success code even if no file is found (file & directory mode)
 protolint lint -reporter junit .            # output results in JUnit XML format
@@ -505,7 +506,7 @@ enum Foo {
 }
 ```
 
-Setting the command-line option `-auto_disable` to `next` or `this` inserts disable commands whenever spotting problems. 
+Setting the command-line option `-auto_disable` to `next` or `this` inserts disable commands whenever spotting problems.
 
 You can specify `-fix` option together. The rules supporting auto_disable suppress the violations instead of fixing them that cause a schema incompatibility.
 


### PR DESCRIPTION
This adds the github action for https://github.com/ossf/scorecard.  I followed the same template used by the docker compose repository in https://github.com/docker/compose/pull/9846 and https://github.com/docker/compose/issues/9845.