### PR TITLE
fix: Proxy Agent usage

### DIFF
--- a/bdist/js/ReadMe.md
+++ b/bdist/js/ReadMe.md
@@ -4,7 +4,7 @@ Protolint is a go based linter for `.proto` files for google protobuf und gRPC. 
 
 The npm package provides a wrapper around the executables `protolint` and `protoc-gen-protolint`. During installation process, it will download the binaries matching the version and your operating system and CPU architecture from github.
 
-If your behind a proxy, you can add the `PROTOLINT_PROXY` environment variable including the HTTP basic authentication information like username and password. **NOTE** that this will take precedence of the system `HTTP_PROXY`/`HTTPS_PROXY` environment variables. If these variables should be used, do not use `PROTOLINT_PROXY`.
+If your behind a proxy, you can add the `PROTOLINT_PROXY` environment variable including the HTTP basic authentication information like username and password. **NOTE** that this will take precedence of the system `HTTP_PROXY`/`HTTPS_PROXY` environment variables. If these variables should be used, do not use `PROTOLINT_PROXY`. If a proxy server is set that should not be used, set `PROTOLINT_NO_PROXY` to non-zero value.
 
 If your running an airgapped environment, you can add the following environment variables:
 

--- a/bdist/js/ReadMe.md
+++ b/bdist/js/ReadMe.md
@@ -4,7 +4,7 @@ Protolint is a go based linter for `.proto` files for google protobuf und gRPC. 
 
 The npm package provides a wrapper around the executables `protolint` and `protoc-gen-protolint`. During installation process, it will download the binaries matching the version and your operating system and CPU architecture from github.
 
-If your behind a proxy, you can add the `PROTOLINT_PROXY` environment variable including the HTTP basic authentication information like username and password.
+If your behind a proxy, you can add the `PROTOLINT_PROXY` environment variable including the HTTP basic authentication information like username and password. **NOTE** that this will take precedence of the system `HTTP_PROXY`/`HTTPS_PROXY` environment variables. If these variables should be used, do not use `PROTOLINT_PROXY`.
 
 If your running an airgapped environment, you can add the following environment variables:
 

--- a/bdist/js/install.mjs
+++ b/bdist/js/install.mjs
@@ -27,8 +27,15 @@ const arch = _arch_mapping[_arch] ?? _arch;
 const url = `${protolint_host}/${protolint_path}/v${protolint_version}/${module_name}_${protolint_version}_${platform}_${arch}.tar.gz`;
 
 let agent;
-if (process.env.PROTOLINT_PROXY) {
-    agent = HttpProxyAgent(process.env.PROTOLINT_PROXY);
+
+let proxy_address = process.env.PROTOLINT_PROXY;
+if (!proxy_address)
+{
+    proxy_address = protolint_host.startsWith("https") ? process.env.HTTPS_PROXY : process.env.HTTP_PROXY;
+}
+
+if (proxy_address) {
+    agent = new HttpProxyAgent(proxy_address);
 }
 
 const agent_config = {

--- a/bdist/js/install.mjs
+++ b/bdist/js/install.mjs
@@ -28,10 +28,14 @@ const url = `${protolint_host}/${protolint_path}/v${protolint_version}/${module_
 
 let agent;
 
-let proxy_address = process.env.PROTOLINT_PROXY;
-if (!proxy_address)
-{
-    proxy_address = protolint_host.startsWith("https") ? process.env.HTTPS_PROXY : process.env.HTTP_PROXY;
+let proxy_address;
+
+if (!process.env.PROTOLINT_NO_PROXY) {
+    proxy_address = process.env.PROTOLINT_PROXY;
+    if (!proxy_address)
+    {
+        proxy_address = protolint_host.startsWith("https") ? process.env.HTTPS_PROXY : process.env.HTTP_PROXY;
+    }
 }
 
 if (proxy_address) {


### PR DESCRIPTION
The proxy variable will be used correctly. The HTTPS_PROXY / HTTP_PROXY will be used, if PROTOLINT_PROXY is not set.

Evaluation takes place: if the remote url starts with https, HTTPS_PROXY will be used, otherwise HTTP_PROXY will be used.
This interpretation is questionable, but makes sense in the first place.

Closes #426