### PR TITLE
Configure 'Got' to use HttpsProxyAgent for https URLs

### DIFF
--- a/bdist/js/install.mjs
+++ b/bdist/js/install.mjs
@@ -2,6 +2,7 @@ import { got } from 'got';
 import { createFetch } from 'got-fetch';
 import npmlog from 'npmlog';
 import { HttpProxyAgent } from 'http-proxy-agent';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import * as fs from 'fs';
 import { temporaryFile } from 'tempy';
 import * as tar from 'tar';
@@ -26,7 +27,8 @@ const arch = _arch_mapping[_arch] ?? _arch;
 
 const url = `${protolint_host}/${protolint_path}/v${protolint_version}/${module_name}_${protolint_version}_${platform}_${arch}.tar.gz`;
 
-let agent;
+let httpAgent;
+let httpsAgent;
 
 let proxy_address;
 
@@ -39,11 +41,13 @@ if (!process.env.PROTOLINT_NO_PROXY) {
 }
 
 if (proxy_address) {
-    agent = new HttpProxyAgent(proxy_address);
+    httpAgent = new HttpProxyAgent(proxy_address);
+    httpsAgent = new HttpsProxyAgent(proxy_address);
 }
 
 const agent_config = {
-    http: agent
+    http: httpAgent,
+    https: httpsAgent
 };
 
 const got_config = {

--- a/bdist/js/package-lock.json
+++ b/bdist/js/package-lock.json
@@ -13,6 +13,7 @@
         "got": "^12.0.0",
         "got-fetch": "^5.1.6",
         "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
         "npmlog": "^7.0.1",
         "semver": "^7.5.4",
         "tar": "^6.2.0",
@@ -333,6 +334,19 @@
       },
       "engines": {
         "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/is-fullwidth-code-point": {

--- a/bdist/js/package.json
+++ b/bdist/js/package.json
@@ -44,6 +44,7 @@
     "got": "^12.0.0",
     "got-fetch": "^5.1.6",
     "http-proxy-agent": "^7.0.0",
+    "https-proxy-agent": "^7.0.0",
     "npmlog": "^7.0.1",
     "semver": "^7.5.4",
     "tar": "^6.2.0",


### PR DESCRIPTION
Configure 'Got' to use `HttpsProxyAgent` for `https` URLs 
(e.g. when default protolint host is used as in `https://github.com/yoheimuta/protolint/releases/download/....`)

Related to #427

@carstencodes  I would really appreciate it if you could take a look at it.
