### PR TITLE
Add version flag support to protolint command

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ protolint lint -output_file=path/to/out.txt # output results to path/to/out.txt
 protolint lint -plugin ./my_custom_rule1 -plugin ./my_custom_rule2 .   # run custom lint rules.
 protolint list                              # list all current lint rules being used
 protolint version                           # print protolint version
+protolint --version                         # print protolint version (global flag)
+protolint -v                                # print protolint version (when used as the only argument)
 ```
 
 protolint does not require configuration by default, for the majority of projects it should work out of the box.

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -16,11 +16,16 @@ Protocol Buffer Linter Command.
 
 Usage:
 	protolint <command> [arguments]
+	protolint --version
 
 The commands are:
 	lint     lint protocol buffer files
 	list     list all current lint rules being used
 	version  print protolint version
+
+The flags are:
+	--version  print protolint version
+	-v         print protolint version (when used as the only argument)
 `
 )
 
@@ -41,6 +46,13 @@ func Do(
 	stdout io.Writer,
 	stderr io.Writer,
 ) osutil.ExitCode {
+	// Check for --version flag
+	for _, arg := range args {
+		if arg == "--version" || (arg == "-v" && len(args) == 1) {
+			return doVersion(stdout)
+		}
+	}
+
 	switch {
 	case len(args) == 0:
 		_, _ = fmt.Fprint(stderr, help)


### PR DESCRIPTION
Introduce support for the `--version` and `-v` flags to display the protolint version. Update documentation to reflect these changes.