### PR TITLE
Add release automation script to streamline the release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,6 +566,20 @@ I wrote an article comparing various Protocol Buffer Linters, including protolin
 
 - [go-protoparser](https://github.com/yoheimuta/go-protoparser)
 
+## Development 
+
+### Release
+
+To streamline the release process and reduce human error, a `release.sh` script is included in the repository. This script automates the steps required to create and push a new release tag.
+
+### How to Use
+
+Run the following command to create a new release:
+
+```bash
+bash release.sh <version> [message]
+```
+
 ## License
 
 The MIT License (MIT)

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Check if a version tag is provided
+if [ -z "$1" ]; then
+  echo "Usage: $0 <version>"
+  exit 1
+fi
+
+VERSION=$1
+MESSAGE=${2:-"Release $VERSION"}
+
+# Switch to the master branch and pull the latest changes
+git checkout master
+git pull
+
+# Create a new tag
+git tag -a "$VERSION" -m "$MESSAGE"
+
+# Push the tag to the remote repository
+git push origin "$VERSION"
+
+echo "Release $VERSION created and pushed successfully."


### PR DESCRIPTION
Introduce a `release.sh` script to automate the creation and pushing of release tags, reducing human error in the release process. Update the README to include usage instructions for the new script.