### PR TITLE
refactor: replace execFile with spawn for better process handling

### DIFF
--- a/bdist/js/bin/protoc-gen-protolint.js
+++ b/bdist/js/bin/protoc-gen-protolint.js
@@ -3,7 +3,7 @@
 'use strict';
 
 var path = require('path');
-var execFile = require('child_process').execFile;
+var spawn = require('child_process').spawn;
 
 var exe_ext = process.platform === 'win32' ? '.exe' : '';
 
@@ -11,10 +11,9 @@ var protoc = path.resolve(__dirname, 'protoc-gen-protolint' + exe_ext);
 
 var args = process.argv.slice(2);
 
-var child_process = execFile(protoc, args, null);
-
-child_process.stdout.pipe(process.stdout);
-child_process.stderr.pipe(process.stderr);
+var child_process = spawn(protoc, args, {
+  stdio: 'inherit' // This inherits stdin, stdout, and stderr
+});
 
 child_process.on("exit", (exit_code, _) => {
     process.exit(exit_code);

--- a/bdist/js/bin/protolint.js
+++ b/bdist/js/bin/protolint.js
@@ -3,7 +3,7 @@
 'use strict';
 
 var path = require('path');
-var execFile = require('child_process').execFile;
+var spawn = require('child_process').spawn;
 
 var exe_ext = process.platform === 'win32' ? '.exe' : '';
 
@@ -11,12 +11,10 @@ var protoc = path.resolve(__dirname, 'protolint' + exe_ext);
 
 var args = process.argv.slice(2);
 
-var child_process = execFile(protoc, args, null);
-
-child_process.stdout.pipe(process.stdout);
-child_process.stderr.pipe(process.stderr);
+var child_process = spawn(protoc, args, {
+  stdio: 'inherit' // This inherits stdin, stdout, and stderr
+});
 
 child_process.on("exit", (exit_code, _) => {
     process.exit(exit_code);
 });
-


### PR DESCRIPTION
To run `npx protolint --mcp.`