### PR TITLE
Fix library usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,11 +273,24 @@ You can also use protolint from Go code.
 See [Go Documentation](https://pkg.go.dev/github.com/yoheimuta/protolint/lib) and [lib/lint_test.go](https://github.com/yoheimuta/protolint/blob/master/lib/lint_test.go) in detail.
 
 ```go
-args := []string{"-config_path", "path/to/your_protolint.yaml", "."}
-var stdout bytes.Buffer
-var stderr bytes.Buffer
+import (
+    "bytes"
+    
+    "github.com/yoheimuta/protolint/lib"
+)
 
-err := lib.Lint(test.inputArgs, &stdout, &stderr)
+func main() {
+    args := []string{"-config_path", "path/to/your_protolint.yaml", "."}
+    var stdout bytes.Buffer
+    var stderr bytes.Buffer
+    
+    err := lib.Lint(args, &stdout, &stderr)
+    if err != nil {
+        // Handle error
+    }
+    
+    // Process output in stdout and stderr
+}
 ```
 
 ## Rules

--- a/internal/cmd/lint_runner.go
+++ b/internal/cmd/lint_runner.go
@@ -3,11 +3,11 @@ package cmd
 import (
 	"io"
 
+	"github.com/yoheimuta/protolint/internal/libinternal"
 	"github.com/yoheimuta/protolint/internal/osutil"
-	"github.com/yoheimuta/protolint/lib"
 )
 
-// CmdLintRunner implements the lib.LintRunner interface for cmd package
+// CmdLintRunner implements the LintRunner interface for cmd package
 type CmdLintRunner struct{}
 
 // NewCmdLintRunner creates a new CmdLintRunner
@@ -20,7 +20,7 @@ func (r *CmdLintRunner) Run(args []string, stdout, stderr io.Writer) osutil.Exit
 	return Do(args, stdout, stderr)
 }
 
-// Initialize registers the cmd lint runner with the lib package
+// Initialize registers the cmd lint runner with the internal library
 func Initialize() {
-	lib.SetLintRunner(NewCmdLintRunner())
+	libinternal.SetLintRunner(NewCmdLintRunner())
 }

--- a/lib/lint.go
+++ b/lib/lint.go
@@ -26,6 +26,11 @@ func SetLintRunner(runner LintRunner) {
 	defaultRunner = runner
 }
 
+// GetLintRunner returns the current lint runner
+func GetLintRunner() LintRunner {
+	return defaultRunner
+}
+
 // Lint is used to lint Protocol Buffer files with the protolint tool.
 // It takes an array of strings (args) representing command line arguments,
 // as well as two io.Writer instances (stdout and stderr) to which the output of the command should be written.

--- a/lib/lint_test.go
+++ b/lib/lint_test.go
@@ -11,6 +11,14 @@ import (
 )
 
 func TestLint(t *testing.T) {
+	// Set the mock lint runner for testing
+	originalRunner := lib.GetLintRunner() // Save the original runner to restore later
+	lib.SetLintRunner(NewMockLintRunner())
+	defer func() {
+		// Restore the original runner after the test
+		lib.SetLintRunner(originalRunner)
+	}()
+
 	tests := []struct {
 		name            string
 		inputArgs       []string

--- a/lib/mock_lint_runner_test.go
+++ b/lib/mock_lint_runner_test.go
@@ -1,4 +1,4 @@
-package lib
+package lib_test
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/yoheimuta/protolint/internal/osutil"
+	"github.com/yoheimuta/protolint/lib"
 )
 
 // MockLintRunner is a mock implementation of LintRunner for testing
@@ -38,7 +39,7 @@ func (r *MockLintRunner) Run(args []string, stdout, stderr io.Writer) osutil.Exi
 	return osutil.ExitSuccess
 }
 
-func init() {
-	// Set the default runner to our mock implementation
-	SetLintRunner(&MockLintRunner{})
+// NewMockLintRunner creates a new MockLintRunner
+func NewMockLintRunner() lib.LintRunner {
+	return &MockLintRunner{}
 }

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/yoheimuta/protolint/lib"
+	"github.com/yoheimuta/protolint/internal/libinternal"
 )
 
 // Tool defines the interface for MCP tools
@@ -92,12 +92,12 @@ func (t *LintFilesTool) Execute(args json.RawMessage) (any, error) {
 	var errorBuffer bytes.Buffer
 
 	// Run lint command
-	err := lib.Lint(cmdArgs, &outputBuffer, &errorBuffer)
+	err := libinternal.Lint(cmdArgs, &outputBuffer, &errorBuffer)
 
 	// Determine exit code based on error
 	exitCode := 0
 	if err != nil {
-		if err == lib.ErrLintFailure {
+		if err == libinternal.ErrLintFailure {
 			exitCode = 1
 		} else {
 			exitCode = 2


### PR DESCRIPTION
This pull request refactors the `protolint` codebase to improve modularity by introducing a new `libinternal` package and updating the usage of linting functionality across the project. It also includes changes to streamline testing and enhance error handling. Below is a summary of the most important changes:

### Refactoring for Modularity

* Introduced a new `libinternal` package to encapsulate core linting logic, including the `Lint` function, `LintRunner` interface, and error definitions (`ErrLintFailure` and `ErrInternalFailure`). This improves separation of concerns and reduces coupling between internal components (`internal/libinternal/lint.go`).
* Updated the `lib` package to delegate linting logic to `libinternal`, simplifying its implementation. The `lib.Lint` function now auto-initializes the default runner if none is set (`lib/lint.go`). [[1]](diffhunk://#diff-21c409d9a496fbc7b7a418c3ba4fde9cadb74628bf606d266ca3189e7b36792bL4-R27) [[2]](diffhunk://#diff-21c409d9a496fbc7b7a418c3ba4fde9cadb74628bf606d266ca3189e7b36792bR36-R46)

### Code Adjustments for Refactoring

* Replaced direct usage of the `lib` package with `libinternal` in various files, such as `cmd/lint_runner.go` and `mcp/tools.go`, to align with the new modular structure. This includes changes to function calls and error handling (`internal/cmd/lint_runner.go`, `mcp/tools.go`). [[1]](diffhunk://#diff-9f16bbd58d1f0d0785e7e458f4b6a7be7b627b3142745c87a2961ca42e155c79R6-R10) [[2]](diffhunk://#diff-9f16bbd58d1f0d0785e7e458f4b6a7be7b627b3142745c87a2961ca42e155c79L23-R25) [[3]](diffhunk://#diff-59d5ab23d41361dff210dcead061dde90fc1ac89fb4920bff3b2bd5e51286786L9-R9) [[4]](diffhunk://#diff-59d5ab23d41361dff210dcead061dde90fc1ac89fb4920bff3b2bd5e51286786L95-R100)

### Testing Enhancements

* Refactored the mock implementation of `LintRunner` into a separate test package (`lib_test`) and introduced a `NewMockLintRunner` function for cleaner test setup. This ensures the original runner is restored after tests (`lib/mock_lint_runner_test.go`). [[1]](diffhunk://#diff-0d4702ae522a64ab581ddf39bcc8556e492228b4bbf5b7be25fa922203c04b39L1-R9) [[2]](diffhunk://#diff-0d4702ae522a64ab581ddf39bcc8556e492228b4bbf5b7be25fa922203c04b39L41-R44)
* Updated `lib/lint_test.go` to use the new `NewMockLintRunner` function for testing, ensuring isolation and maintainability of test cases.

### Documentation Updates

* Updated the `README.md` file to include a more comprehensive example of using `protolint` from Go code, demonstrating error handling and output processing (`README.md`).