### PR TITLE
Fix disabling FILE_NAMES_LOWER_SNAKE_CASE

### DIFF
--- a/_testdata/rules/fileNamesLowerSnakeCase/dot.separated.proto
+++ b/_testdata/rules/fileNamesLowerSnakeCase/dot.separated.proto
@@ -1,0 +1,2 @@
+// protolint:disable FILE_NAMES_LOWER_SNAKE_CASE
+syntax = "proto3";

--- a/internal/addon/rules/fileNamesLowerSnakeCaseRule.go
+++ b/internal/addon/rules/fileNamesLowerSnakeCaseRule.go
@@ -67,8 +67,8 @@ type fileNamesLowerSnakeCaseVisitor struct {
 	fixMode  bool
 }
 
-// OnStart checks the file.
-func (v *fileNamesLowerSnakeCaseVisitor) OnStart(proto *parser.Proto) error {
+// Finally checks the file name and renames it if necessary.
+func (v *fileNamesLowerSnakeCaseVisitor) Finally(proto *parser.Proto) error {
 	path := proto.Meta.Filename
 	if stringsutil.ContainsStringInSlice(path, v.excluded) {
 		return nil

--- a/internal/addon/rules/fileNamesLowerSnakeCaseRule_test.go
+++ b/internal/addon/rules/fileNamesLowerSnakeCaseRule_test.go
@@ -55,6 +55,19 @@ func TestFileNamesLowerSnakeCaseRule_Apply(t *testing.T) {
 			},
 		},
 		{
+			name: "no failures for proto with disable directive",
+			inputProto: &parser.Proto{
+				Meta: &parser.ProtoMeta{
+					Filename: "proto/lowerSnakeCase.proto",
+				},
+				ProtoBody: []parser.Visitee{
+					&parser.Comment{
+						Raw: "// protolint:disable FILE_NAMES_LOWER_SNAKE_CASE",
+					},
+				},
+			},
+		},
+		{
 			name: "a failure for proto with a camel case file name",
 			inputProto: &parser.Proto{
 				Meta: &parser.ProtoMeta{
@@ -185,6 +198,11 @@ func TestFileNamesLowerSnakeCaseRule_Apply_fix(t *testing.T) {
 			inputFilename: "kebab-case.proto",
 			wantFilename:  "kebab_case.proto",
 		},
+		{
+			name:          "no fix for a proto with disable directive",
+			inputFilename: "dot.separated.proto",
+			wantFilename:  "dot.separated.proto",
+		},
 	}
 
 	for _, test := range tests {
@@ -198,6 +216,7 @@ func TestFileNamesLowerSnakeCaseRule_Apply_fix(t *testing.T) {
 				t.Errorf("got err %v", err)
 				return
 			}
+
 			proto, err := file.NewProtoFile(input.FilePath, input.FilePath).Parse(false)
 			if err != nil {
 				t.Errorf("%v", err.Error())

--- a/internal/addon/rules/importsSortedRule.go
+++ b/internal/addon/rules/importsSortedRule.go
@@ -70,7 +70,7 @@ func (v importsSortedVisitor) VisitImport(i *parser.Import) (next bool) {
 	return false
 }
 
-func (v importsSortedVisitor) Finally() error {
+func (v importsSortedVisitor) Finally(proto *parser.Proto) error {
 	notSorted := v.sorter.notSortedImports()
 
 	v.Fixer.ReplaceAll(func(lines []string) []string {
@@ -91,7 +91,7 @@ func (v importsSortedVisitor) Finally() error {
 	if !v.fixMode {
 		return nil
 	}
-	return v.BaseFixableVisitor.Finally()
+	return v.BaseFixableVisitor.Finally(proto)
 }
 
 type notSortedImport struct {

--- a/internal/addon/rules/indentRule.go
+++ b/internal/addon/rules/indentRule.go
@@ -97,9 +97,9 @@ type indentVisitor struct {
 	indentFixes      map[int][]indentFix
 }
 
-func (v indentVisitor) Finally() error {
+func (v indentVisitor) Finally(proto *parser.Proto) error {
 	if v.fixMode {
-		return v.fix()
+		return v.fix(proto)
 	}
 	return nil
 }
@@ -358,7 +358,7 @@ func (v *indentVisitor) nest() func() {
 	}
 }
 
-func (v indentVisitor) fix() error {
+func (v indentVisitor) fix(proto *parser.Proto) error {
 	var shouldFixed bool
 
 	v.Fixer.ReplaceAll(func(lines []string) []string {
@@ -410,5 +410,5 @@ func (v indentVisitor) fix() error {
 	if !shouldFixed {
 		return nil
 	}
-	return v.BaseFixableVisitor.Finally()
+	return v.BaseFixableVisitor.Finally(proto)
 }

--- a/internal/addon/rules/orderRule.go
+++ b/internal/addon/rules/orderRule.go
@@ -71,7 +71,7 @@ type orderVisitor struct {
 	formatter formatter
 }
 
-func (v *orderVisitor) Finally() error {
+func (v *orderVisitor) Finally(proto *parser.Proto) error {
 	if 0 < len(v.Failures()) {
 		shouldFixed := true
 		v.Fixer.ReplaceContent(func(content []byte) []byte {
@@ -84,7 +84,7 @@ func (v *orderVisitor) Finally() error {
 
 		// TODO: BaseFixableVisitor.Finally should run the base Finally first, and then the fixing later.
 		if shouldFixed {
-			return v.BaseFixableVisitor.Finally()
+			return v.BaseFixableVisitor.Finally(proto)
 		}
 	}
 	return nil

--- a/linter/visitor/baseFixableVisitor.go
+++ b/linter/visitor/baseFixableVisitor.go
@@ -32,10 +32,10 @@ func NewBaseFixableVisitor(
 }
 
 // Finally fixes the proto file by overwriting it.
-func (v *BaseFixableVisitor) Finally() error {
+func (v *BaseFixableVisitor) Finally(proto *parser.Proto) error {
 	err := v.finallyFn()
 	if err != nil {
 		return err
 	}
-	return v.BaseAddVisitor.Finally()
+	return v.BaseAddVisitor.Finally(proto)
 }

--- a/linter/visitor/baseVisitor.go
+++ b/linter/visitor/baseVisitor.go
@@ -7,11 +7,8 @@ import (
 // BaseVisitor represents a base visitor with noop logic.
 type BaseVisitor struct{}
 
-// OnStart works noop.
-func (BaseVisitor) OnStart(*parser.Proto) error { return nil }
-
 // Finally works noop.
-func (BaseVisitor) Finally() error { return nil }
+func (BaseVisitor) Finally(*parser.Proto) error { return nil }
 
 // VisitComment works noop.
 func (BaseVisitor) VisitComment(*parser.Comment) {}

--- a/linter/visitor/extendedAutoDisableVisitor.go
+++ b/linter/visitor/extendedAutoDisableVisitor.go
@@ -28,13 +28,12 @@ func newExtendedAutoDisableVisitor(
 	}, nil
 }
 
-func (v *extendedAutoDisableVisitor) OnStart(p *parser.Proto) error { return v.inner.OnStart(p) }
-func (v *extendedAutoDisableVisitor) Finally() error {
+func (v *extendedAutoDisableVisitor) Finally(p *parser.Proto) error {
 	err := v.automator.Finalize()
 	if err != nil {
 		return err
 	}
-	return v.inner.Finally()
+	return v.inner.Finally(p)
 }
 func (v *extendedAutoDisableVisitor) Failures() []report.Failure { return v.inner.Failures() }
 

--- a/linter/visitor/extendedDisableRuleVisitor.go
+++ b/linter/visitor/extendedDisableRuleVisitor.go
@@ -24,9 +24,13 @@ func newExtendedDisableRuleVisitor(
 	}
 }
 
-func (v extendedDisableRuleVisitor) OnStart(p *parser.Proto) error { return v.inner.OnStart(p) }
-func (v extendedDisableRuleVisitor) Finally() error                { return v.inner.Finally() }
-func (v extendedDisableRuleVisitor) Failures() []report.Failure    { return v.inner.Failures() }
+func (v extendedDisableRuleVisitor) Finally(p *parser.Proto) error {
+	if v.interpreter.Interpret([]*parser.Comment{}) {
+		return nil
+	}
+	return v.inner.Finally(p)
+}
+func (v extendedDisableRuleVisitor) Failures() []report.Failure { return v.inner.Failures() }
 func (v extendedDisableRuleVisitor) VisitEmptyStatement(e *parser.EmptyStatement) (next bool) {
 	return v.inner.VisitEmptyStatement(e)
 }

--- a/linter/visitor/hasExtendedVisitor.go
+++ b/linter/visitor/hasExtendedVisitor.go
@@ -11,10 +11,8 @@ import (
 type HasExtendedVisitor interface {
 	parser.Visitor
 
-	// OnStart is called when visiting is started.
-	OnStart(*parser.Proto) error
 	// Finally is called when visiting is done.
-	Finally() error
+	Finally(*parser.Proto) error
 	// Failures returns the accumulated failures.
 	Failures() []report.Failure
 }
@@ -49,11 +47,8 @@ func RunVisitorAutoDisable(
 		ruleID,
 	)
 
-	if err := disabled.OnStart(proto); err != nil {
-		return nil, err
-	}
 	proto.Accept(disabled)
-	if err := disabled.Finally(); err != nil {
+	if err := disabled.Finally(proto); err != nil {
 		return nil, err
 	}
 	return disabled.Failures(), nil


### PR DESCRIPTION
This pull request introduces several changes to enhance the functionality of proto file linting, primarily by refactoring the `Finally` methods across various visitors to accept a `*parser.Proto` parameter. Additionally, it improves handling of file name rules and introduces new test cases to validate these updates.

### Refactoring of Visitor Methods:

* Updated the `Finally` method in `BaseVisitor`, `BaseFixableVisitor`, and other visitor implementations (`indentVisitor`, `orderVisitor`, etc.) to accept a `*parser.Proto` parameter for better context during finalization. [[1]](diffhunk://#diff-28d606329e28c8e507cfb0f3bc42c8a26427ad7c5a3f7b1585f383d1f8fb1c7eL10-R11) [[2]](diffhunk://#diff-6e2dde8ae2b692cf264af1badca44eb929f582b58ecc00b875373f709eec47cfL35-R40) [[3]](diffhunk://#diff-2d997f749705f98166c302d787bc7c3e40ca10e1d6229a3a425ed3b31ce1ecd8L100-R102) [[4]](diffhunk://#diff-ca97000107fb6bdc3c8ac7e8d410769b626eec976fa7956e034abdd78cf14a79L74-R74) [[5]](diffhunk://#diff-063ab4fb777d0ba11cb9d773e41a20dee07a856f0edff2ab262bfab7bfe50dccL73-R73)

* Modified the `extendedAutoDisableVisitor` and `extendedDisableRuleVisitor` to pass the `*parser.Proto` object to their inner visitors during the `Finally` method call. [[1]](diffhunk://#diff-925bb7f0bb8f6f5011cea01b1b1c99253e34bf5127eb2ba3e0ca0ae6bf0393ebL31-R36) [[2]](diffhunk://#diff-a6b5dc0ac72cf766ba195c44ffdb7a700acac4f41e2d337def4634d2a672d9faL27-R32)

### File Name Rule Enhancements:

* Introduced support for disabling the `FILE_NAMES_LOWER_SNAKE_CASE` rule using a directive (`// protolint:disable FILE_NAMES_LOWER_SNAKE_CASE`) in proto files.

* Adjusted the `fileNamesLowerSnakeCaseVisitor` to rename files only when the rule is not disabled and updated its `Finally` method for clarity.

### Test Case Additions:

* Added test cases to verify that the `FILE_NAMES_LOWER_SNAKE_CASE` rule is correctly disabled when the directive is present and that no renaming occurs in such cases. [[1]](diffhunk://#diff-c771eaeefd462c9c8c27386eaa3831de7d514ee62e570a22237b81dac0d83ca7R57-R69) [[2]](diffhunk://#diff-c771eaeefd462c9c8c27386eaa3831de7d514ee62e570a22237b81dac0d83ca7R201-R205)

* Enhanced the test suite for `Finally` method behavior, ensuring proper handling of the `*parser.Proto` parameter across various scenarios.

### Interface and Usage Adjustments:

* Updated the `HasExtendedVisitor` interface to remove the `OnStart` method and modify the `Finally` method to accept a `*parser.Proto` parameter. Adjusted the `RunVisitorAutoDisable` function accordingly. [[1]](diffhunk://#diff-e9258317903ed9acf1b9643f96e6b32ecd4d30e4138ce47e61064f0052f7b24fL14-R15) [[2]](diffhunk://#diff-e9258317903ed9acf1b9643f96e6b32ecd4d30e4138ce47e61064f0052f7b24fL52-R51)