### PR TITLE
Set minimum Go version to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,4 +25,4 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a // indirect
 )
 
-go 1.24.2
+go 1.23.0


### PR DESCRIPTION
In a recent change (8ffaae4, chore: update Go version to 1.24.2), we upgraded the minimum Go version in `go.mod` from Go 1.23 to Go 1.24.2. The intention was seemingly to have the CI jobs to run with a newer Go version. Since we updated the minimum version in `go.mod`, the module is no longer usable from modules that support earlier Go versions as well.

Drop the required Go version to back to 1.23. It doesn't seem like we use any 1.24 features that would require us to bump the minimum version.