### PR TITLE
refactor: replace deprecated io/ioutil with io and os

### DIFF
--- a/internal/cmd/protocgenprotolint/cmd.go
+++ b/internal/cmd/protocgenprotolint/cmd.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,7 +77,7 @@ func newSubCmd(
 	stdout io.Writer,
 	stderr io.Writer,
 ) (*lint.CmdLint, error) {
-	data, err := ioutil.ReadAll(stdin)
+	data, err := io.ReadAll(stdin)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/osutil/file.go
+++ b/internal/osutil/file.go
@@ -3,7 +3,6 @@ package osutil
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -20,7 +19,7 @@ func ReadAllLines(
 	fileName string,
 	newlineChar string,
 ) ([]string, error) {
-	data, err := ioutil.ReadFile(fileName)
+	data, err := os.ReadFile(fileName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util_test/testFile.go
+++ b/internal/util_test/testFile.go
@@ -1,7 +1,7 @@
 package util_test
 
 import (
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/yoheimuta/protolint/internal/osutil"
@@ -17,7 +17,7 @@ type TestData struct {
 func NewTestData(
 	filePath string,
 ) (TestData, error) {
-	data, err := ioutil.ReadFile(filePath)
+	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return TestData{}, nil
 	}
@@ -29,7 +29,7 @@ func NewTestData(
 
 // Data returns a content.
 func (d TestData) Data() ([]byte, error) {
-	return ioutil.ReadFile(d.FilePath)
+	return os.ReadFile(d.FilePath)
 }
 
 // Restore writes the original content back to the file.

--- a/linter/fixer/fixer.go
+++ b/linter/fixer/fixer.go
@@ -2,7 +2,7 @@ package fixer
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/yoheimuta/go-protoparser/v4/lexer"
@@ -56,7 +56,7 @@ type BaseFixing struct {
 
 // NewBaseFixing creates a BaseFixing.
 func NewBaseFixing(protoFileName string) (*BaseFixing, error) {
-	content, err := ioutil.ReadFile(protoFileName)
+	content, err := os.ReadFile(protoFileName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR replaces function usages from `io/ioutil` with the same functions from `io` and `os`.

## Changes

- replace `ioutil.ReadFile` with `os.ReadFile`
- replace `ioutil.ReadAll` with `io.ReadAll`

## Motivation

[io/ioutil](https://pkg.go.dev/io/ioutil) is deprecated:

> Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code. See the specific function documentation for details.