### PR TITLE
Feat/lint cache and stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ You can add the linter configuration to the `tools.protolint` package in `pyproj
 protolint lint example.proto example2.proto # file mode, specify multiple specific files
 protolint lint .                            # directory mode, search for all .proto files recursively
 protolint .                                 # same as "protolint lint ."
+protolint lint -stdin_filename=v1/f.proto - # read from stdin and assume its path is v1/f.proto
 protolint lint -config_path=path/to/your_protolint.yaml . # use path/to/your_protolint.yaml
 protolint lint -config_dir_path=path/to .   # search path/to for .protolint.yaml
 protolint lint -fix .                       # automatically fix some of the problems reported by some rules
@@ -156,6 +157,26 @@ protolint -v                                # print protolint version (when used
 ```
 
 protolint does not require configuration by default, for the majority of projects it should work out of the box.
+
+### Linting from stdin
+
+You can lint Protobuf content from standard input by using `-` as the file path. 
+This is particularly useful for integration with scripts or IDEs.
+
+```sh
+cat example.proto | protolint lint -
+```
+
+If you need to provide a virtual filename for [configuration](#configuring)
+resolution or for more descriptive error reporting, use the `-stdin_filename`
+flag:
+
+```sh
+cat example.proto | protolint lint -stdin_filename=api/v1/user.proto -
+```
+
+Note: linting from stdin support does not currently support `-fix` or
+`-auto_disable` modes, as these involve editing the physical file in-place.
 
 ## Version Control Integration
 

--- a/internal/addon/rules/maxLineLengthRule.go
+++ b/internal/addon/rules/maxLineLengthRule.go
@@ -2,13 +2,13 @@ package rules
 
 import (
 	"bufio"
-	"os"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/yoheimuta/go-protoparser/v4/parser"
 	"github.com/yoheimuta/go-protoparser/v4/parser/meta"
 
+	"github.com/yoheimuta/protolint/internal/file"
 	"github.com/yoheimuta/protolint/linter/disablerule"
 	"github.com/yoheimuta/protolint/linter/report"
 	"github.com/yoheimuta/protolint/linter/rule"
@@ -70,7 +70,7 @@ func (r MaxLineLengthRule) Apply(proto *parser.Proto) (
 	err error,
 ) {
 	fileName := proto.Meta.Filename
-	reader, err := os.Open(fileName)
+	reader, err := file.Open(fileName)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/subcmds/lint/cmdLint.go
+++ b/internal/cmd/subcmds/lint/cmdLint.go
@@ -23,7 +23,7 @@ type CmdLint struct {
 	l          *linter.Linter
 	stdout     io.Writer
 	stderr     io.Writer
-	protoFiles []file.ProtoFile
+	protoFiles []*file.ProtoFile
 	config     CmdLintConfig
 	output     io.Writer
 }
@@ -34,7 +34,7 @@ func NewCmdLint(
 	stdout io.Writer,
 	stderr io.Writer,
 ) (*CmdLint, error) {
-	protoSet, err := file.NewProtoSet(flags.FilePaths)
+	protoSet, err := file.NewProtoSet(flags.FilePaths, flags.StdinFilename)
 	if err != nil {
 		return nil, err
 	}
@@ -94,6 +94,14 @@ func (c *CmdLint) Run() osutil.ExitCode {
 }
 
 func (c *CmdLint) run() ([]report.Failure, error) {
+	if c.config.IsModifyingMode() {
+		for _, f := range c.protoFiles {
+			if f.IsStdin() {
+				return nil, fmt.Errorf("fix and auto_disable modes are not supported for stdin")
+			}
+		}
+	}
+
 	var allFailures []report.Failure
 
 	for _, f := range c.protoFiles {
@@ -116,7 +124,7 @@ func (p ParseError) Error() string {
 }
 
 func (c *CmdLint) runOneFile(
-	f file.ProtoFile,
+	f *file.ProtoFile,
 ) ([]report.Failure, error) {
 	// Gen rules first
 	// If there is no rule, we can skip parse proto file
@@ -129,11 +137,20 @@ func (c *CmdLint) runOneFile(
 	}
 
 	return c.l.Run(func(p *parser.Proto) (*parser.Proto, error) {
+		if !c.config.IsModifyingMode() && p != nil {
+			return p, nil
+		}
+
 		// Recreate a protoFile if the previous rule changed the filename.
 		if p != nil && p.Meta.Filename != f.DisplayPath() {
 			newFilename := p.Meta.Filename
 			newBase := filepath.Base(newFilename)
 			f = file.NewProtoFile(filepath.Join(filepath.Dir(f.Path()), newBase), newFilename)
+		}
+
+		if c.config.IsModifyingMode() {
+			f.ResetCache()
+			f.ResetData()
 		}
 
 		proto, err := f.Parse(c.config.verbose)

--- a/internal/cmd/subcmds/lint/cmdLintConfig.go
+++ b/internal/cmd/subcmds/lint/cmdLintConfig.go
@@ -50,7 +50,7 @@ func NewCmdLintConfig(
 
 // GenRules generates rules which are applied to the filename path.
 func (c CmdLintConfig) GenRules(
-	f file.ProtoFile,
+	f *file.ProtoFile,
 ) ([]rule.HasApply, error) {
 	allRules, err := subcmds.NewAllRules(c.external.Lint.RulesOption, c.fixMode, c.autoDisableType, c.verbose, c.plugins)
 	if err != nil {
@@ -73,4 +73,9 @@ func (c CmdLintConfig) GenRules(
 	}
 
 	return hasApplies, nil
+}
+
+// IsModifyingMode returns true if the linter is in a mode that modifies files.
+func (c CmdLintConfig) IsModifyingMode() bool {
+	return c.fixMode || c.autoDisableType != autodisable.Noop
 }

--- a/internal/cmd/subcmds/lint/cmdLint_test.go
+++ b/internal/cmd/subcmds/lint/cmdLint_test.go
@@ -1,0 +1,52 @@
+package lint
+
+import (
+	"io"
+	"testing"
+)
+
+func TestCmdLint_Run_FailFastOnStdinWithModification(t *testing.T) {
+	fixMode, _ := NewFlags([]string{"-fix", "-stdin_filename=file.proto", "-"})
+	autoDisable, _ := NewFlags([]string{"-auto_disable=next", "-stdin_filename=file.proto", "-"})
+	correct, _ := NewFlags([]string{"-stdin_filename=file.proto", "-"})
+
+	tests := []struct {
+		name        string
+		flags       Flags
+		expectError bool
+	}{
+		{
+			name:        "stdin with fix mode should fail",
+			flags:       fixMode,
+			expectError: true,
+		},
+		{
+			name:        "stdin with auto-disable should fail",
+			flags:       autoDisable,
+			expectError: true,
+		},
+		{
+			name:        "stdin without modification should pass",
+			flags:       correct,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, _ := NewCmdLint(tt.flags, io.Discard, io.Discard)
+
+			_, err := c.run()
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error, but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("got unexpected error")
+				}
+			}
+		})
+	}
+}

--- a/internal/cmd/subcmds/lint/flags.go
+++ b/internal/cmd/subcmds/lint/flags.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 
 	"github.com/yoheimuta/protolint/internal/cmd/subcmds"
+	"github.com/yoheimuta/protolint/internal/file"
 	"github.com/yoheimuta/protolint/linter/autodisable"
 
 	"github.com/yoheimuta/protolint/internal/addon/plugin/shared"
@@ -28,6 +29,7 @@ type Flags struct {
 	NoErrorOnUnmatchedPattern bool
 	Plugins                   []shared.RuleSet
 	AdditionalReporters       reporterStreamFlags
+	StdinFilename             string
 }
 
 // NewFlags creates a new Flags.
@@ -100,7 +102,12 @@ func NewFlags(
 		"add-reporter",
 		"Adds a reporter to the list of reporters to use. The format should be 'name of reporter':'Path-To_output_file'",
 	)
-
+	f.StringVar(
+		&f.StdinFilename,
+		"stdin_filename",
+		file.StdinDisplayPath,
+		"a filename for the text passed via stdin.",
+	)
 	_ = f.Parse(args)
 	if rf.reporter != nil {
 		f.Reporter = rf.reporter

--- a/internal/file/vfs.go
+++ b/internal/file/vfs.go
@@ -1,0 +1,61 @@
+package file
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"sync"
+)
+
+const (
+	// StdinPath is the magic symbol representing stdin.
+	StdinPath = "-"
+	// StdinDisplayPath is the default filename used for displaying stdin results.
+	StdinDisplayPath = "stdin.proto"
+)
+
+var (
+	// virtualFiles maps file paths to their raw byte content in memory.
+	// This allows shadowing disk files or providing stdin content to rules.
+	virtualFiles = make(map[string][]byte)
+	// mu protects concurrent access to the virtualFiles map.
+	mu sync.RWMutex
+)
+
+// SetVirtualFile registers raw byte content for a specific path in the virtual file system.
+// This is typically used to cache stdin content so it can be read multiple times by different rules.
+func SetVirtualFile(path string, data []byte) {
+	mu.Lock()
+	defer mu.Unlock()
+	virtualFiles[path] = data
+}
+
+// Open opens a file for reading.
+// It returns a reader from memory if the path is registered in the virtual file system,
+// otherwise it falls back to opening a physical file from the disk.
+func Open(path string) (io.ReadCloser, error) {
+	mu.RLock()
+	data, ok := virtualFiles[path]
+	mu.RUnlock()
+
+	if ok {
+		return io.NopCloser(bytes.NewReader(data)), nil
+	}
+
+	return os.Open(path)
+}
+
+// ReadFile reads the entire named file into a byte slice.
+// It returns data from memory if the path is registered in the virtual file system,
+// otherwise it reads from the physical disk using os.ReadFile.
+func ReadFile(path string) ([]byte, error) {
+	mu.RLock()
+	data, ok := virtualFiles[path]
+	mu.RUnlock()
+
+	if ok {
+		return data, nil
+	}
+
+	return os.ReadFile(path)
+}

--- a/internal/file/vfs_test.go
+++ b/internal/file/vfs_test.go
@@ -1,0 +1,82 @@
+package file_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/yoheimuta/protolint/internal/file"
+)
+
+func TestVFS_Concurrency(t *testing.T) {
+	var wg sync.WaitGroup
+	workers := 100
+
+	for i := range workers {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+
+			path := fmt.Sprintf("virtual-%d.proto", id)
+			content := fmt.Appendf(nil, "content-%d", id)
+
+			// Wtite to the map with mutex
+			file.SetVirtualFile(path, content)
+
+			// Read from the map
+			got, err := file.ReadFile(path)
+			if err != nil {
+				t.Errorf("worker %d: failed to read: %v", id, err)
+				return
+			}
+
+			if !bytes.Equal(got, content) {
+				t.Errorf("worker %d: data corruption! expected %s, got %s", id, content, got)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestOpen_VirtualAndPhysical(t *testing.T) {
+	// 1. Test Virtual Access
+	virtualPath := "virtual_test.proto"
+	virtualContent := []byte("syntax = 'proto3';")
+	file.SetVirtualFile(virtualPath, virtualContent)
+	defer file.SetVirtualFile(virtualPath, nil)
+
+	r, err := file.Open(virtualPath)
+	if err != nil {
+		t.Fatalf("Open(virtual) failed: %v", err)
+	}
+
+	got, err := io.ReadAll(r)
+	_ = r.Close() // Essential to test if it closes without panic
+	if err != nil {
+		t.Fatalf("ReadAll(virtual) failed: %v", err)
+	}
+	if !bytes.Equal(got, virtualContent) {
+		t.Errorf("expected %s, got %s", virtualContent, got)
+	}
+
+	// 2. Test Physical Fallback (using a real file)
+	tmpFile, _ := os.CreateTemp("", "physical.proto")
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	physicalContent := []byte("physical content")
+	if err := os.WriteFile(tmpFile.Name(), physicalContent, 0644); err != nil {
+		t.Fatalf("failed to write tmp file: %v", err)
+	}
+
+	r2, err := file.Open(tmpFile.Name())
+	if err != nil {
+		t.Fatalf("Open(physical) failed: %v", err)
+	}
+	got2, _ := io.ReadAll(r2)
+	_ = r2.Close()
+	if !bytes.Equal(got2, physicalContent) {
+		t.Errorf("expected %s, got %s", physicalContent, got2)
+	}
+}

--- a/internal/linter/file/protoFile.go
+++ b/internal/linter/file/protoFile.go
@@ -1,10 +1,13 @@
 package file
 
 import (
+	"bytes"
+	"io"
 	"os"
 
 	protoparser "github.com/yoheimuta/go-protoparser/v4"
 	"github.com/yoheimuta/go-protoparser/v4/parser"
+	"github.com/yoheimuta/protolint/internal/file"
 )
 
 // ProtoFile is a Protocol Buffer file.
@@ -17,36 +20,56 @@ type ProtoFile struct {
 	// This will be relative to the working directory, or the absolute path
 	// if the file was outside the working directory.
 	displayPath string
+	// cachedData holds the raw byte content of the file.
+	// It is used to support stdin reading and to avoid redundant disk I/O.
+	cachedData []byte
+	// cachedProto holds the parsed protocol buffer definition.
+	// It is used to avoid redundant parsing across multiple rules.
+	cachedProto *parser.Proto
 }
 
 // NewProtoFile creates a new proto file.
 func NewProtoFile(
 	path string,
 	displayPath string,
-) ProtoFile {
-	return ProtoFile{
+) *ProtoFile {
+	return &ProtoFile{
 		path:        path,
 		displayPath: displayPath,
 	}
 }
 
 // Parse parses a Protocol Buffer file.
-func (f ProtoFile) Parse(
+func (f *ProtoFile) Parse(
 	debug bool,
-) (_ *parser.Proto, err error) {
-	reader, err := os.Open(f.path)
-	if err != nil {
-		return nil, err
+) (*parser.Proto, error) {
+	if f.cachedProto != nil {
+		return f.cachedProto, nil
 	}
-	defer func() {
-		closeErr := reader.Close()
+
+	if f.cachedData == nil {
+		var data []byte
+		var err error
+
+		if f.IsStdin() {
+			data, err = io.ReadAll(os.Stdin)
+
+			if err == nil {
+				file.SetVirtualFile(file.StdinPath, data)
+				file.SetVirtualFile(f.displayPath, data)
+			}
+		} else {
+			data, err = os.ReadFile(f.path)
+		}
+
 		if err != nil {
-			return
+			return nil, err
 		}
-		if closeErr != nil {
-			err = closeErr
-		}
-	}()
+
+		f.cachedData = data
+	}
+
+	reader := bytes.NewReader(f.cachedData)
 
 	proto, err := protoparser.Parse(
 		reader,
@@ -57,15 +80,39 @@ func (f ProtoFile) Parse(
 	if err != nil {
 		return nil, err
 	}
-	return proto, nil
+
+	f.cachedProto = proto
+	return f.cachedProto, nil
 }
 
 // Path returns the path to the .proto file.
-func (f ProtoFile) Path() string {
+func (f *ProtoFile) Path() string {
 	return f.path
 }
 
 // DisplayPath returns the path to display in output.
-func (f ProtoFile) DisplayPath() string {
+func (f *ProtoFile) DisplayPath() string {
 	return f.displayPath
+}
+
+// IsStdin returns true if the .proto text was received via stdin.
+func (f *ProtoFile) IsStdin() bool {
+	return f.path == file.StdinPath
+}
+
+// ResetData clears the cached raw byte content for physical files.
+// It does not clear the cache for stdin, as stdin can only be read once.
+// This is used during modifying commands like 'lint -fix' to re-read updated
+// content from the disk.
+func (f *ProtoFile) ResetData() {
+	if f.path != file.StdinPath {
+		f.cachedData = nil
+	}
+}
+
+// ResetCache clears the cached protocol buffer definition.
+// This is used during modifying commands like 'lint -fix' to ensure the next
+// rule works with a fresh parse if the previous rule modified the file.
+func (f *ProtoFile) ResetCache() {
+	f.cachedProto = nil
 }

--- a/internal/linter/file/protoFile_test.go
+++ b/internal/linter/file/protoFile_test.go
@@ -1,0 +1,47 @@
+package file_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/yoheimuta/protolint/internal/linter/file"
+)
+
+func TestProtoFile_ParseCachingAndReset(t *testing.T) {
+	content := []byte("syntax = 'proto3';")
+	tmpFile, _ := os.CreateTemp("", "test.proto")
+	defer func() { _ = os.Remove(tmpFile.Name()) }()
+	if err := os.WriteFile(tmpFile.Name(), content, 0644); err != nil {
+		t.Fatalf("failed to write tmp file: %v", err)
+	}
+
+	f := file.NewProtoFile(tmpFile.Name(), "test.proto")
+
+	// Parse and fill the cache in
+	p1, err := f.Parse(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Change the file on disk
+	newContent := []byte("syntax = 'proto3'; message New {}")
+	if err := os.WriteFile(tmpFile.Name(), newContent, 0644); err != nil {
+		t.Fatalf("failed to write tmp file: %v", err)
+	}
+
+	// Parsing with no reset should return p1
+	p2, _ := f.Parse(false)
+	if p1 != p2 {
+		t.Errorf("expected cached protocol buffer definition, but got a new one")
+	}
+
+	// Reset cache and data (imitate a modifying mode)
+	f.ResetCache()
+	f.ResetData()
+
+	// Parsing after reset should return a new data
+	p3, _ := f.Parse(false)
+	if p1 == p3 {
+		t.Errorf("expected a new protocol buffer definition after reset, but got the old one")
+	}
+}

--- a/internal/linter/file/protoSet.go
+++ b/internal/linter/file/protoSet.go
@@ -4,18 +4,31 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/yoheimuta/protolint/internal/file"
 )
 
 // ProtoSet represents a set of .proto files.
 type ProtoSet struct {
-	protoFiles []ProtoFile
+	protoFiles []*ProtoFile
 }
 
 // NewProtoSet creates a new ProtoSet.
 func NewProtoSet(
 	targetPaths []string,
+	stdinFileName string,
 ) (ProtoSet, error) {
-	fs, err := collectAllProtoFilesFromArgs(targetPaths)
+	stdinCount := 0
+	for _, path := range targetPaths {
+		if path == file.StdinPath {
+			stdinCount++
+		}
+	}
+	if stdinCount > 1 {
+		return ProtoSet{}, fmt.Errorf("stdin (%s) can only be specified once", file.StdinPath)
+	}
+
+	fs, err := collectAllProtoFilesFromArgs(targetPaths, stdinFileName)
 	if err != nil {
 		return ProtoSet{}, err
 	}
@@ -29,13 +42,14 @@ func NewProtoSet(
 }
 
 // ProtoFiles returns proto files.
-func (s ProtoSet) ProtoFiles() []ProtoFile {
+func (s *ProtoSet) ProtoFiles() []*ProtoFile {
 	return s.protoFiles
 }
 
 func collectAllProtoFilesFromArgs(
 	targetPaths []string,
-) ([]ProtoFile, error) {
+	stdinFileName string,
+) ([]*ProtoFile, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, err
@@ -49,8 +63,17 @@ func collectAllProtoFilesFromArgs(
 		absCwd = newPath
 	}
 
-	var fs []ProtoFile
+	var fs []*ProtoFile
 	for _, path := range targetPaths {
+		if path == file.StdinPath {
+			displayPath := file.StdinDisplayPath
+			if stdinFileName != "" {
+				displayPath = stdinFileName
+			}
+			fs = append(fs, NewProtoFile(file.StdinPath, stdinFilenameClean(absCwd, displayPath)))
+			continue
+		}
+
 		absTarget, err := absClean(path)
 		if err != nil {
 			return nil, err
@@ -68,8 +91,8 @@ func collectAllProtoFilesFromArgs(
 func collectAllProtoFiles(
 	absWorkDirPath string,
 	absPath string,
-) ([]ProtoFile, error) {
-	var fs []ProtoFile
+) ([]*ProtoFile, error) {
+	var fs []*ProtoFile
 
 	err := filepath.Walk(
 		absPath,
@@ -105,4 +128,27 @@ func absClean(path string) (string, error) {
 		return filepath.Abs(path)
 	}
 	return filepath.Clean(path), nil
+}
+
+// stdinFilenameClean returns a normalized path for content received via stdin.
+// It attempts to make the targpath absolute and then calculates its relative path
+// with respect to basepath (usually the current working directory).
+//
+// This normalization is crucial for the linter to correctly match the file
+// against configuration-specific rules defined in .protolint.yaml, which typically
+// use paths relative to the project root.
+//
+// If the path cannot be made relative (e.g., different drive letters on Windows),
+// it returns the cleaned absolute path.
+func stdinFilenameClean(basepath, targpath string) string {
+	target, err := absClean(targpath)
+	if err != nil {
+		target = targpath
+	}
+
+	if relative, err := filepath.Rel(basepath, target); err == nil {
+		return relative
+	}
+
+	return target
 }

--- a/internal/linter/file/protoSet_test.go
+++ b/internal/linter/file/protoSet_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	vfs "github.com/yoheimuta/protolint/internal/file"
 	"github.com/yoheimuta/protolint/internal/linter/file"
 	"github.com/yoheimuta/protolint/internal/setting_test"
 )
@@ -12,7 +13,7 @@ func TestNewProtoSet(t *testing.T) {
 	tests := []struct {
 		name             string
 		inputTargetPaths []string
-		wantProtoFiles   []file.ProtoFile
+		wantProtoFiles   []*file.ProtoFile
 		wantExistErr     bool
 	}{
 		{
@@ -34,7 +35,7 @@ func TestNewProtoSet(t *testing.T) {
 			inputTargetPaths: []string{
 				setting_test.TestDataPath("testdir", "innerdir"),
 			},
-			wantProtoFiles: []file.ProtoFile{
+			wantProtoFiles: []*file.ProtoFile{
 				file.NewProtoFile(
 					filepath.Join(setting_test.TestDataPath("testdir", "innerdir"), "/testinner.proto"),
 					"../../../_testdata/testdir/innerdir/testinner.proto",
@@ -46,7 +47,7 @@ func TestNewProtoSet(t *testing.T) {
 			inputTargetPaths: []string{
 				setting_test.TestDataPath("testdir"),
 			},
-			wantProtoFiles: []file.ProtoFile{
+			wantProtoFiles: []*file.ProtoFile{
 				file.NewProtoFile(
 					filepath.Join(setting_test.TestDataPath("testdir", "innerdir"), "/testinner.proto"),
 					"../../../_testdata/testdir/innerdir/testinner.proto",
@@ -66,7 +67,7 @@ func TestNewProtoSet(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			got, err := file.NewProtoSet(test.inputTargetPaths)
+			got, err := file.NewProtoSet(test.inputTargetPaths, "")
 			if test.wantExistErr {
 				if err == nil {
 					t.Errorf("got err nil, but want err")
@@ -88,5 +89,45 @@ func TestNewProtoSet(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestNewProtoSet_MixedMode(t *testing.T) {
+	// Setup: One real file and the stdin magic path
+	realFile := setting_test.TestDataPath("testdir", "test.proto")
+	inputPaths := []string{realFile, vfs.StdinPath}
+
+	ps, err := file.NewProtoSet(inputPaths, "virtual_stdin.proto")
+	if err != nil {
+		t.Fatalf("NewProtoSet failed: %v", err)
+	}
+
+	files := ps.ProtoFiles()
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d", len(files))
+	}
+
+	// Verify the first one is the real file
+	if files[0].Path() != realFile {
+		t.Errorf("expected first file to be %s, got %s", realFile, files[0].Path())
+	}
+
+	// Verify the second one is our virtual stdin
+	if !files[1].IsStdin() {
+		t.Errorf("expected second file to be stdin")
+	}
+	if files[1].DisplayPath() != "virtual_stdin.proto" {
+		t.Errorf("expected virtual display path, got %s", files[1].DisplayPath())
+	}
+}
+
+func TestNewProtoSet_MultipleStdinError(t *testing.T) {
+	// Scenario: User tries to pass "-" twice in the arguments
+	inputPaths := []string{vfs.StdinPath, "other.proto", vfs.StdinPath}
+	virtualName := "any.proto"
+
+	_, err := file.NewProtoSet(inputPaths, virtualName)
+	if err == nil {
+		t.Fatal("expected error when providing multiple stdin paths, but got nil")
 	}
 }

--- a/linter/fixer/fixer.go
+++ b/linter/fixer/fixer.go
@@ -2,7 +2,6 @@ package fixer
 
 import (
 	"bytes"
-	"os"
 	"strings"
 
 	"github.com/yoheimuta/go-protoparser/v4/lexer"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/yoheimuta/go-protoparser/v4/parser"
 
+	"github.com/yoheimuta/protolint/internal/file"
 	"github.com/yoheimuta/protolint/internal/osutil"
 )
 
@@ -56,7 +56,7 @@ type BaseFixing struct {
 
 // NewBaseFixing creates a BaseFixing.
 func NewBaseFixing(protoFileName string) (*BaseFixing, error) {
-	content, err := os.ReadFile(protoFileName)
+	content, err := file.ReadFile(protoFileName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Summary:**

Addresses #443

> The majority of time is spent parsing

This PR introduces support for linting from `stdin` and significantly improves performance for linting by implementing an in-memory AST cache.

**Key Improvements:**

**Performance (~7.2x faster)**: By caching the parsed AST and raw file content, we eliminated redundant disk I/O and parsing cycles. 

Benchmark ([googleapis/google/ads](https://github.com/googleapis/googleapis/tree/8f70147e819ed25cc75c73c4037ce64f9cbb68db/google/ads), WSL + Ubuntu): **Master:** 54s → **This PR:** 7.5s.

<details><summary>Benchmarking script</summary>

```shell
#!/bin/bash
BINARY=$1
# We use the relative path to the google folder
TARGET_DIR="./ads/"

echo "Benchmarking: $BINARY"

for i in {1..3}; do
  echo -n "Run $i: "
  # We use 'time' and redirect output to /dev/null to see only the speed
  { time $BINARY lint $TARGET_DIR > /dev/null 2>&1; } 2>&1 | grep real
done
``` 
</details>

<img width="1126" height="218" alt="image" src="https://github.com/user-attachments/assets/b83f574c-3814-470e-ac00-63b2a995c051" />

**Virtual File System (VFS)**: Implemented a thread-safe, memory-first VFS wrapper (`file.Open`, `file.ReadFile`). This allows rules to access stdin content or "shadow" disk files without physical file handles.

**LSP Ready**: The architecture is now thread-safe (using `sync.RWMutex`) and supports virtual filenames, making it good for future Language Server Protocol (LSP) integrations.

**MCP** can potentially benefit from piping file buffers directly into the linter. This enables faster, more secure "lint-as-you-type" or "AI-fix" workflows without the overhead of temporary file management.

**WASM** Readiness:
This refactoring prepares `protolint` for high-performance WebAssembly (WASI) execution. By implementing a memory-first VFS and single-pass parsing, we've eliminated the costly I/O overhead typical in WASM runtimes.

I've also tested it in my LSP draft. This optimization brings WASM linting time for a ~600 line file down from 250+ms to ~54ms, making real-time IDE integration viable.

**Robust Validation**: Implemented fail-fast guards to prevent incompatible flag combinations (like `-fix` with `stdin`).

**Technical Details:**
*   Changed `ProtoFile` to a pointer-based receiver to maintain state across the linter lifecycle.
*   Added `cachedData` and `cachedProto` fields to avoid re-parsing for each of the rules.