### PR TITLE
docs: add MegaLinter to CI Integration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ Jenkins Plugins
 
 - [warnings-ng](https://github.com/jenkinsci/warnings-ng-plugin) and any that use [violatons-lib](https://github.com/tomasbjerre/violations-lib)
 
+Linters aggregator
+
+- [MegaLinter](https://megalinter.io/) runs [protolint](https://megalinter.io/latest/descriptors/protobuf_protolint/) out of the box among its many embedded linters
+
 ### Environment specific output
 
 It is possible to format your linting according to the formatting of the CI/CD environment. The environment must be set using the output format. Currently, the following output is realized:


### PR DESCRIPTION
Hi! I maintain [MegaLinter](https://megalinter.io/), an open-source linters aggregator for CI, and protolint has been embedded in it out of the box for a while now.

This PR just adds a small line about it in the CI Integration section of the README.

By the way, if you spot anything wrong or outdated on protolint's page in the MegaLinter docs, I'd be happy to fix it: https://megalinter.io/latest/descriptors/protobuf_protolint/

Thanks for protolint!