### PR TITLE
ci: publish npm via trusted publishing instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/publish_npm.yml
+++ b/.github/workflows/publish_npm.yml
@@ -7,6 +7,12 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+  # Required to mint the OIDC token that npm trusted publishing exchanges for a
+  # short-lived publish credential (cf. https://docs.npmjs.com/trusted-publishers)
+  id-token: write
+
 jobs:
   publish_npm:
     name: Publish NPM
@@ -19,39 +25,19 @@ jobs:
       - name: Install node.js
         uses: actions/setup-node@v6
         with:
-          node-version-file: ./bdist/js/package.json
+          # Trusted publishing needs Node >= 22.14.0 and npm >= 11.5.1, which is
+          # stricter than the engines range in ./bdist/js/package.json.
+          node-version: 24
+          registry-url: https://registry.npmjs.org
       - name: Install dependencies
         working-directory: ./bdist/js
         run: npm ci --omit=dev --ignore-scripts --no-audit --no-fund
       - name: Set package version
         working-directory: ./bdist/js
         run: npm version from-git --no-git-tag-version
-      - name: Issue warning if NPM_TOKEN is not set
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "::warning title=Missing authentication token::In order to publish an NPM package, you must set the NPM_TOKEN secret"
-        if: ${{ env.NODE_AUTH_TOKEN == '' }}
-      - name: Issue warning if NPM_EMAIL is not set
-        env:
-          NPM_EMAIL: ${{ secrets.NPM_EMAIL }}
-        run: |
-          echo "::warning title=Missing authentication information::In order to publish an NPM package, you must set the NPM_EMAIL secret"
-        if: ${{ env.NPM_EMAIL == '' }}
-      - name: Create .npmrc file
-        env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_EMAIL: ${{ secrets.NPM_EMAIL }}
-        run: |
-          # Use project specific npmrc file (cf. https://docs.npmjs.com/cli/v6/using-npm/config)
-          # Use scoped AUTH TOKEN (cf. https://docs.npmjs.com/cli/v9/configuring-npm/npmrc#auth-related-configuration)
-          echo "//registry.npmjs.org/:_authToken = $NPM_AUTH_TOKEN" >> .npmrc
-          echo "email = $NPM_EMAIL" >> .npmrc
-        working-directory: ./bdist/js
-        if: ${{ env.NPM_AUTH_TOKEN != '' }}
+      # No NPM_TOKEN needed: the package is published through a trusted publisher
+      # configured on npmjs.com for this repository and workflow file name.
+      # Provenance is attached automatically, so do not pass --provenance.
       - name: Publish NPM package
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish
         working-directory: ./bdist/js
-        if: ${{ env.NODE_AUTH_TOKEN != '' }}
+        run: npm publish


### PR DESCRIPTION
Fixes the npm half of #557.

## What happened

`v0.57.0` is tagged and `goreleaser` succeeded — GitHub Releases (9 assets), PyPI (`0.57.0`), Docker Hub, Homebrew and Maven Central are all out. Only [Publish NPM](https://github.com/yoheimuta/protolint/actions/runs/31792361160) failed:

```
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/protolint - Not found
npm error 404  The requested resource 'protolint@0.57.0' could not be found or you do not have permission to access it.
```

`E404` on `PUT` for an existing public package is npm's way of reporting an auth failure. The `NPM_TOKEN` secret was created `2023-10-01` and never rotated, so it was caught by npm's revocation of long-lived classic tokens. That is also why the last npm release was a year ago while every other distribution channel kept shipping — nothing surfaced the dead credential.

## The change

Switch to [trusted publishing](https://docs.npmjs.com/trusted-publishers): GitHub mints an OIDC token, npm exchanges it for a short-lived publish credential. There is no stored secret left to expire, and provenance is attached automatically.

- add `id-token: write` (plus explicit `contents: read`)
- add `registry-url` to `setup-node`, and pin `node-version: 24` — trusted publishing needs Node >= 22.14.0 / npm >= 11.5.1, which is stricter than the `>=20.18.1` engines range the workflow was resolving from `package.json`
- drop the `.npmrc` creation, the `NPM_TOKEN`/`NPM_EMAIL` warning steps and the `NODE_AUTH_TOKEN` env

No `--provenance` flag: it is implicit under trusted publishing.

## Required manual step

Before this can publish, a trusted publisher has to be configured once on npmjs.com for the `protolint` package:

npmjs.com -> Packages -> protolint -> Settings -> **Trusted Publisher**, then under *Select your publisher* choose **GitHub Actions**:

| Field | Value |
|---|---|
| Organization or user | `yoheimuta` |
| Repository | `protolint` |
| Workflow filename | `publish_npm.yml` |
| Environment name | *(leave empty)* |
| Allowed actions | `npm publish` |

The workflow filename must match exactly, extension included.

## Releasing 0.57.0 after merge

No new tag is needed — `v0.57.0` is on `master` HEAD, so `npm version from-git` resolves to `0.57.0`. Just re-run the workflow via `workflow_dispatch`.

Verified locally against a clone checked out at `v0.57.0`: `npm version from-git` yields `0.57.0` and the tarball contains `postinstall.js` and both wrappers.

Once npm is green, `NPM_TOKEN` and `NPM_EMAIL` can be deleted from the repository secrets.

<sub>The `bin[...] script name ... was invalid and removed` warning in that log is a red herring — npm only strips the `./` prefix and keeps the entries, matching what `0.56.4` already has on the registry.</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
