### PR TITLE
ci: track stable Go so the @latest linters keep installing

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: 1.24.2
+          # install_dep.sh installs its linters with @latest, so this job needs
+          # whatever Go the newest release of those tools requires.
+          go-version: stable
 
       - name: Lint
         run: |


### PR DESCRIPTION
The `Go / build-and-scan` job currently fails on **every** PR, before running any check:

```
+ go install golang.org/x/tools/cmd/goimports@latest
go: downloading golang.org/x/tools v0.49.0
go: golang.org/x/tools/cmd/goimports@latest: golang.org/x/tools@v0.49.0
   requires go >= 1.25.0 (running go 1.24.2; GOTOOLCHAIN=local)
make: *** [Makefile:35: dev/install/dep] Error 1
```

`.github/install_dep.sh` installs all eight linters with `@latest`, so the job implicitly tracks the newest release of each tool. `x/tools` has since raised its `go` directive to 1.25.0, which the pinned 1.24.2 cannot satisfy — and `actions/setup-go` sets `GOTOOLCHAIN=local`, so the pinned toolchain is not allowed to bootstrap a newer one either.

Pinning to `1.25.x` would fix it until the next tool bumps its requirement. Since the tools themselves are unpinned by design, the Go version for this job should follow them, so this uses `stable`.

Scope is limited to the lint/test job. `goreleaser.yml` keeps its explicit `1.24.2` pin — the released binaries should stay built with a known toolchain, and it does not run these linters.

Found while working on #557 (the npm publish fix in #561 is blocked on a red required check that has nothing to do with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
