### PR TITLE
docs: add release and add-lint-rule runbooks, fix stale Maven steps

### DIFF
--- a/.claude/skills/add-lint-rule/SKILL.md
+++ b/.claude/skills/add-lint-rule/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: add-lint-rule
+description: Add a new lint rule to protolint — every file that has to change, and how the official/unofficial, fixable and auto-disable behaviours are wired. Use when asked to add, implement, or write a new rule.
+---
+
+# Adding a lint rule
+
+A rule is not done when `Apply` works — it has to be registered, made
+configurable, and documented, or it is invisible to users. Copy the closest
+existing rule rather than starting from scratch.
+
+## Files to touch
+
+| File | Always? | What goes in |
+|---|---|---|
+| `internal/addon/rules/<camelCase>Rule.go` | yes | the rule |
+| `internal/addon/rules/<camelCase>Rule_test.go` | yes | table-driven tests |
+| `internal/cmd/subcmds/rules.go` | yes | register in `newAllInternalRules` |
+| `internal/linter/config/rulesOption.go` | yes | one field on `RulesOption` |
+| `README.md` | yes | a row in the `## Rules` table |
+| `_example/config/.protolint.yaml` | yes | a commented example entry |
+| `internal/linter/config/<name>Option.go` (+ test) | only if configurable | a dedicated option type |
+| `_testdata/rules/<name>/*.proto` | when fixtures help | input protos |
+
+Naming is mechanical: rule ID `FIELD_NUMBERS_ORDER_ASCENDING` → type
+`FieldNumbersOrderAscendingRule` → file `fieldNumbersOrderAscendingRule.go` →
+config key `field_numbers_order_ascending`.
+
+## The rule type
+
+Embed `RuleWithSeverity` and implement:
+
+- `ID() string` — `UPPER_SNAKE_CASE`, unique
+- `Purpose() string` — one sentence; it is user-facing and goes in the README verbatim
+- `IsOfficial() bool` — **this decides whether the rule is on by default**
+
+`Rules.Default()` in `internal/linter/rule/rules.go` keeps only rules where
+`IsOfficial()` is true. Return `true` only for rules from the
+[official style guide](https://protobuf.dev/programming-guides/style/); anything
+opinionated returns `false` and users opt in via `.protolint.yaml`.
+
+`Apply(proto *parser.Proto) ([]report.Failure, error)` walks the AST with a
+visitor from `linter/visitor`.
+
+## Fixable and auto-disable
+
+Both are opt-in and both show up as columns in the README table.
+
+- **Fixable** — build the visitor with `visitor.NewBaseFixableVisitor` and take a
+  `fixMode bool` in the constructor. Users get it via `-fix`.
+- **AutoDisable** — take `autoDisableType autodisable.PlacementType`. The
+  constructor must force `fixMode = false` when `autoDisableType != autodisable.Noop`;
+  the two cannot both apply. Users get it via `-auto_disable`.
+
+Rules whose fix cannot break wire compatibility are marked `*1` in the README
+instead of supporting auto-disable — for those, fixing is always safe.
+
+## Configuration
+
+If severity is the only knob, use the shared `CustomizableSeverityOption` in
+`rulesOption.go`. Add a dedicated option type only when the rule needs its own
+settings, and give it a test — these types are parsed from YAML, JSON and TOML,
+so all three struct tags must be present and identical.
+
+## Verify
+
+```bash
+make test/lint && make test
+make run/cmd/protolint ARG="lint _example/proto"
+```
+
+Confirm the rule appears where users will look for it:
+
+```bash
+go run cmd/protolint/main.go list | grep YOUR_RULE_ID
+```
+
+A rule missing from that list was implemented but never registered.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: release
+description: Cut a protolint release — preflight checks, tagging, and verifying that all six distribution channels actually published. Use when asked to release, publish, ship a version, or when a release partially failed and needs diagnosing.
+---
+
+# Releasing protolint
+
+One git tag fans out to six channels. `release.sh` only pushes the tag; everything
+else is CI. The job is mostly **verifying that each channel really published**,
+because they fail independently and silently.
+
+## 1. Preflight
+
+Run from a clean `master` that is in sync with `origin`:
+
+```bash
+go build ./... && go test ./...
+(cd bdist/js && npm ci --ignore-scripts && npx tsc && npx eslint . && npx prettier --check .)
+```
+
+`.github/workflows/go.yml` and the JS workflows only run on `pull_request`, so
+nothing has verified `master` as a whole. Do not skip this.
+
+## 2. Pick the version
+
+Every channel takes its version from the git tag — `.goreleaser.yml` ldflags,
+`build.gradle` from `GITHUB_REF_NAME`, and `npm version from-git`. Nothing needs
+bumping by hand; the tag *is* the version.
+
+Look at what changed since the last tag, and remember the npm package ships to a
+different audience than the Go binary:
+
+- **patch** — Go-side fixes, dependency bumps, docs
+- **minor** — new lint rules, or anything that changes what npm consumers need:
+  a raised `engines.node`, a module-system switch, renamed install scripts
+
+## 3. Tag
+
+```bash
+./release.sh vX.Y.Z "Release vX.Y.Z"
+```
+
+## 4. Watch the pipeline
+
+`goreleaser` runs on the tag push. `publish_npm` and `publish_wheel` then trigger
+off its **completion, not its success** — so a green goreleaser does not mean the
+downstream jobs passed.
+
+```bash
+gh run watch <goreleaser-run-id> --exit-status
+gh run list --workflow publish_npm.yml --limit 1
+gh run list --workflow publish_wheel.yml --limit 1
+```
+
+## 5. Verify every channel
+
+Check the registries, not the workflow badges.
+
+```bash
+gh release view vX.Y.Z --json assets --jq '.assets|length'          # expect 9
+npm view protolint version
+curl -s https://pypi.org/pypi/protolint-bin/json | jq -r .info.version
+curl -s https://repo1.maven.org/maven2/io/github/yoheimuta/protoc-gen-protolint/maven-metadata.xml | grep release
+```
+
+Maven Central publishes automatically via the Central Publisher Portal step in
+`goreleaser.yml` (`publishing_type=automatic`). No manual staging promotion.
+
+Then prove the npm package actually works end to end — this exercises
+`postinstall.js`, which downloads the release binary and is the part most likely
+to break:
+
+```bash
+cd "$(mktemp -d)" && npm init -y >/dev/null && npm install protolint@X.Y.Z
+./node_modules/.bin/protolint version          # must print X.Y.Z
+./node_modules/.bin/protoc-gen-protolint version
+```
+
+## Troubleshooting
+
+**`npm error 404 ... PUT https://registry.npmjs.org/protolint`**
+Authentication, not a missing package. npm publishes through
+[trusted publishing](https://docs.npmjs.com/trusted-publishers) — there is no
+token. Check the trusted publisher on npmjs.com still points at `yoheimuta` /
+`protolint` / `publish_npm.yml`. **Renaming `publish_npm.yml` breaks publishing**,
+because the registration matches on the workflow filename.
+
+**`fatal: No tags can describe '<sha>'` in *Set package version***
+`npm version from-git` needs history back to the tag. `publish_npm.yml` uses
+`fetch-depth: 0` and checks the tag out explicitly for this reason; a shallow
+checkout reintroduces the failure.
+
+**`npm warn publish "bin[protolint]" script name ... was invalid and removed`**
+Harmless. npm only strips the `./` prefix; the published `bin` entries survive.
+Confirm with `npm view protolint@X.Y.Z bin` if in doubt.
+
+**A channel failed after the tag is already public**
+Do not re-tag. Fix the workflow, merge, then re-run the failed workflow with
+`gh workflow run <name>.yml --ref master`. `publish_npm` and `publish_wheel` both
+have `workflow_dispatch`, and `publish_npm` checks out the latest tag, so a re-run
+publishes the tagged tree even after later merges have landed on `master`.
+
+## After the release
+
+Post the version on any issue that asked for it, and close it.

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ atlassian-ide-plugin.xml
 /bdist/js/node_modules/
 /bdist/js/node_modules/*.tgz
 
+# Claude Code local settings (the committed skills under .claude/skills/ are shared)
+.claude/settings.local.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,28 @@
 - Submit a pull request
 
 
-## Publish the Maven artifacts
+## Releasing
 
-Once a release is done, artifacts will need to be promoted in Maven Central to make them generally available.
+`./release.sh <version>` pushes a tag; CI does the rest. A single tag publishes to
+GitHub Releases, npm, PyPI, Maven Central, Docker Hub and Homebrew, and every
+version number is derived from that tag — nothing is bumped by hand.
 
-1. Head over to https://s01.oss.sonatype.org/#stagingRepositories
-1. Verify the contents of the staging repo and close it
-1. After successful closing (test suite is run), release the repo
+The Maven artifacts no longer need to be promoted manually: `goreleaser.yml`
+uploads them to the Central Publisher Portal with `publishing_type=automatic`, so
+they reach Maven Central without a staging step.
+
+npm publishes through [trusted publishing](https://docs.npmjs.com/trusted-publishers)
+rather than a stored token. The registration on npmjs.com matches on the workflow
+**filename**, so renaming `.github/workflows/publish_npm.yml` breaks publishing
+until the trusted publisher is updated to match.
+
+See [`.claude/skills/release/SKILL.md`](.claude/skills/release/SKILL.md) for the
+full runbook, including how to verify each channel and how to recover when one of
+them fails after the tag is already public.
+
+## Adding a lint rule
+
+A rule has to be registered and documented, not just implemented, or users will
+never see it. [`.claude/skills/add-lint-rule/SKILL.md`](.claude/skills/add-lint-rule/SKILL.md)
+lists every file that has to change and explains how the official/unofficial,
+fixable and auto-disable behaviours are wired.

--- a/README.md
+++ b/README.md
@@ -623,6 +623,8 @@ Run the following command to create a new release:
 bash release.sh <version> [message]
 ```
 
+Pushing the tag is only the first step — CI publishes to GitHub Releases, npm, PyPI, Maven Central, Docker Hub and Homebrew from it. See [CONTRIBUTING.md](CONTRIBUTING.md#releasing) for how to verify each channel.
+
 ## License
 
 The MIT License (MIT)


### PR DESCRIPTION
Documents this repo's two recurring jobs as Claude Code skills, and corrects a set of release instructions that no longer match what CI does. Fallout from shipping v0.57.0 (#557).

## The stale part

`CONTRIBUTING.md` told maintainers to promote Maven artifacts by hand:

> Head over to https://s01.oss.sonatype.org/#stagingRepositories … verify the contents of the staging repo and close it

That has not been true for a while. `goreleaser.yml` uploads to the Central Publisher Portal with `publishing_type=automatic`, and today's release confirms it — nobody touched a staging repo, yet:

```
$ curl -s https://repo1.maven.org/maven2/io/github/yoheimuta/protoc-gen-protolint/maven-metadata.xml
  <release>0.57.0</release>
  <lastUpdated>20260814103515</lastUpdated>
```

which is minutes after the goreleaser run finished.

## `.claude/skills/release`

Releasing is more than `release.sh`. One tag fans out to six channels, and `publish_npm` / `publish_wheel` trigger on goreleaser's **completion, not its success** — so a green goreleaser badge is not evidence that anything was published. That is exactly how the npm package sat a year behind while every other channel kept shipping.

The runbook therefore leans on verifying the registries directly rather than the workflow badges, plus an end-to-end `npm install` that exercises `postinstall.js`. It also records the failure modes hit while shipping v0.57.0, so the next person does not have to re-derive them:

- `404 ... PUT https://registry.npmjs.org/protolint` means auth, not a missing package
- renaming `publish_npm.yml` breaks publishing, because the trusted publisher registration matches on the filename
- `fatal: No tags can describe '<sha>'` is a shallow-checkout problem
- the `bin[...] was invalid and removed` warning is harmless
- never re-tag to fix a failed channel; re-run the workflow

## `.claude/skills/add-lint-rule`

Adding a rule spans eight files. Implementing `Apply` without registering the rule in `internal/cmd/subcmds/rules.go` leaves it invisible to users, and `IsOfficial()` quietly decides whether it is enabled by default (`Rules.Default()` filters on it). The skill tabulates every file to touch, the mechanical naming convention, and how fixable / auto-disable are wired.

Verified `go run cmd/protolint/main.go list` behaves as the skill describes.

## Also

- `README.md` gains a pointer from its Release section to the full process
- `.claude/settings.local.json` is gitignored — it is per-developer, and was previously only ignored via a personal global gitignore

🤖 Generated with [Claude Code](https://claude.com/claude-code)
