### PR TITLE
fix: RECORD does not contain correct path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,18 @@
 {
     "name": "protolint devcontainer",
-    "image": "mcr.microsoft.com/devcontainers/go:1.24",
-    "features": {},
+    "image": "mcr.microsoft.com/devcontainers/base:debian",
+    "features": {
+        "ghcr.io/devcontainers/features/node:2": {
+            "version": "lts"
+        },
+        "ghcr.io/devcontainers/features/python:1": {
+            "version": "os-provided",
+            "installTools": false
+        },
+        "ghcr.io/devcontainers/features/go:1": {
+            "version": "latest"
+        }
+    },
     "customizations": {
         "vscode": {
             "settings": {
@@ -11,5 +22,6 @@
                 "golang.go"
             ]
         }
-    }
+    },
+    "postCreateCommand": "sh -c 'go install github.com/goreleaser/goreleaser/v2@latest'"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,8 @@ atlassian-ide-plugin.xml
 /bdist/js/node_modules/
 /bdist/js/node_modules/*.tgz
 
+# Go releaser files
+/dist
+
 # Claude Code local settings (the committed skills under .claude/skills/ are shared)
 .claude/settings.local.json

--- a/bdist/py/setup.py
+++ b/bdist/py/setup.py
@@ -34,6 +34,17 @@ def clear_dir(path):
         logger.debug("Removing directory %s", path)
         path.rmdir()
 
+def sanitize_entry(path, parent):
+    path_value = str(path)
+    parent_value = str(parent)
+    if (path_value.startswith(parent_value)):
+        path_value = path_value[len(parent_value):]
+
+    if path_value.startswith('/') or path_value.startswith('\\'):
+        path_value = path_value.lstrip('/').lstrip('\\')
+
+    return path_value
+
 
 logger = logging.getLogger("BUILD")
 logger.setLevel(logging.INFO)
@@ -161,7 +172,7 @@ for arch_platform in ap_map.keys():
                 ml.writelines(readme.readlines())
 
         wheel_content = list(distInfoFolder.glob("**/*")) + list(dataFolder.glob("**/*"))
-        elements_to_relative_paths = {entry: str(entry)[len(str(pdir)):].lstrip("/").lstrip("\\") for entry in wheel_content if entry.is_file()}
+        elements_to_relative_paths = {entry: sanitize_entry(entry, pdir) for entry in wheel_content if entry.is_file()}
         with (distInfoFolder / "RECORD").open("w+", encoding="utf-8") as rl:
             logger.debug("Writing RECORD file")
             for entry in elements_to_relative_paths.keys():

--- a/bdist/py/setup.py
+++ b/bdist/py/setup.py
@@ -161,11 +161,12 @@ for arch_platform in ap_map.keys():
                 ml.writelines(readme.readlines())
 
         wheel_content = list(distInfoFolder.glob("**/*")) + list(dataFolder.glob("**/*"))
-        elements_to_relative_paths = {entry: str(entry).lstrip(str(pdir)).lstrip("/").lstrip("\\") for entry in wheel_content if entry.is_file()}
+        elements_to_relative_paths = {entry: str(entry)[len(str(pdir)):].lstrip("/").lstrip("\\") for entry in wheel_content if entry.is_file()}
         with (distInfoFolder / "RECORD").open("w+", encoding="utf-8") as rl:
             logger.debug("Writing RECORD file")
             for entry in elements_to_relative_paths.keys():
                 relPath = elements_to_relative_paths[entry]
+                logger.debug("Setting record for %s using relative path %s", entry, relPath)
                 sha256 = hashlib.sha256(entry.read_bytes())
                 fs = entry.stat().st_size
                 rl.write(f"{relPath},sha256={sha256.hexdigest()},{str(fs)}\n")


### PR DESCRIPTION
The RECORD file contained erroneous file entries.
This seems to be an issue with lstrip behavior. Better use substring to update.

[Note: This Issue was fixed on a codespace. To make the codespace run, the devcontainer was updated]

Closes #560